### PR TITLE
Version bump with minor dev environment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,50 @@ See at [https://namebazaar.io](https://namebazaar.io)
 
 Smart-contracts can be found [here](https://github.com/district0x/name-bazaar/tree/master/resources/public/contracts/src).
 
-## Start dev server
+## Starting a dev server with an Ethereum Testnet
+
+In a terminal, start a ganache blockchain
+
 ```bash
-# In separete terminal start Ganache blockchain
 ganache-cli -p 8549
+```
 
-# In separate terminal start autocompiling smart-contracts
+Open another terminal, start autocompiling smart-contracts
+
+```bash
 lein auto compile-solidity
+```
 
-# In separate terminal start server REPL
-git clone https://github.com/district0x/name-bazaar
-lein deps
+Open another terminal, start a repl and build the dev server (with
+figwheel repl)
+
+```bash
 lein repl
 (start-server!)
+```
 
-# In separate terminal run server
+Figwheel will prompt for a connection for the repl instance.
+
+Open another terminal, run the compiled server script, which should
+connect to the figwheel repl.
+
+```bash
 node dev-server/name-bazaar.js
 ```
+
 #### Redeploy smart-contracts and generate mock data
+
 ```bash
-# In server REPL run:
-(name-bazaar.server.dev/redeploy)
+# In the figwheel server REPL run:
+(redeploy)
 ```
+
+Redeployment / Generation can take a long time, please be patient.
+
+
 #### Start server with custom config
 Namebazaar uses [district-server-config](https://github.com/district0x/district-server-config) for loading configuration. So you can create `config.edn` somewhat like this:
+
 ```clojure
 {:emailer {:private-key "25677d268904ea651f84e37cfd580696c5c793dcd9730c415bf03b96003c09e9ef8"
            :print-mode? true}
@@ -42,17 +62,41 @@ Namebazaar uses [district-server-config](https://github.com/district0x/district-
  :web3 {:port 8549}
  :endpoints {:port 6200}}
 ```
+
 ## Start dev UI
+
+If you wish to connect to the dev server discussed above, open a
+separate terminal, and build the client-side ui
+
 ```bash
 lein repl
 (start-ui!)
+```
 
-# In separate terminal run
+You can then connect to the server through a web browser at http://localhost:4541
+
+## Start a development UI for client-side development only
+
+If you're only focusing on working with the UI, you can start a UI
+interface which connects to the production server using mainnet.
+
+```bash
+lein repl
+(start-ui! :ui-only? true)
+```
+
+In separate terminal, start the supplied docker nginx server
+
+```bash
 docker-compose build nginx
 docker-compose up nginx
 
 # Visit website at http://localhost:3001
 ```
+
+**Note: using this client is using the main ethereum network, it is
+ill-advised to carry out transactions unless you know what you are doing!**
+
 
 ## Backend (server) tests:
 
@@ -86,7 +130,9 @@ docker-compose up nginx
 and start (start-ui!), (start-server!) as usual, but open the site on http://localhost:3001
 
 ## Build for production
+
 Following commands are used to build system for production
+
 ```bash
 lein build-prod-server
 lein build-prod-ui

--- a/dev/cljs/user.cljs
+++ b/dev/cljs/user.cljs
@@ -1,0 +1,22 @@
+(ns cljs.user
+  (:require
+   [name-bazaar.server.dev]
+   [taoensso.timbre :as timbre :refer-macros [warn info]]))
+
+
+(info "Initialized Development Environment!")
+(info "Run (redeploy) in the CLJS REPL for a fresh environment.")
+
+
+;; Redeploy Smart Contracts
+;; Note: this can cause the REPL to timeout while executing.
+(defn redeploy []
+  (warn "Redeployment is a long process, please be patient...")
+  (.nextTick
+   js/process
+   (fn []
+     (name-bazaar.server.dev/redeploy)
+     (info "Redeployment Finished!"))))
+
+
+(set! *main-cli-fn* name-bazaar.server.dev/-main)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,6 +1,7 @@
 (ns user
   (:require [figwheel-sidecar.repl-api]))
 
+
 (defn start-server! []
   (figwheel-sidecar.repl-api/start-figwheel!
     (assoc-in (figwheel-sidecar.config/fetch-config)
@@ -8,11 +9,15 @@
     "dev-server")
   (figwheel-sidecar.repl-api/cljs-repl "dev-server"))
 
-(defn start-ui! []
-  (figwheel-sidecar.repl-api/start-figwheel!
-    (figwheel-sidecar.config/fetch-config)
-    "dev")
-  (figwheel-sidecar.repl-api/cljs-repl "dev"))
+
+(defn start-ui!
+  [& {:keys [ui-only?] :or {ui-only? false}}]
+  (let [dev-build-id (if ui-only? "dev-ui-only" "dev-ui")]
+   (figwheel-sidecar.repl-api/start-figwheel!
+     (figwheel-sidecar.config/fetch-config)
+     dev-build-id)
+   (figwheel-sidecar.repl-api/cljs-repl dev-build-id)))
+
 
 (defn start-tests! []
   (figwheel-sidecar.repl-api/start-figwheel!
@@ -20,6 +25,7 @@
               [:data :figwheel-options :server-port] 4543)
     "server-tests")
   (figwheel-sidecar.repl-api/cljs-repl "server-tests"))
+
 
 (comment
   (start-ui!)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,30 +1,46 @@
 (ns user
-  (:require [figwheel-sidecar.repl-api]))
+  (:require
+   [com.rpl.specter :as s] 
+   [figwheel-sidecar.repl-api :as fw-repl]
+   [figwheel-sidecar.config :as fw-config]
+   [taoensso.timbre :as timbre :refer [info]]))
+
+
+(defn set-closure-define
+  "Sets the :closure-defines for the given `build-id` in the given
+  figwheel config `config`"
+  [config build-id key value]
+  (s/setval
+   [:data :all-builds (s/filterer #(= (:id %) build-id)) s/FIRST
+    (s/keypath :build-options :closure-defines key)]
+   value config))
 
 
 (defn start-server! []
-  (figwheel-sidecar.repl-api/start-figwheel!
-    (assoc-in (figwheel-sidecar.config/fetch-config)
-              [:data :figwheel-options :server-port] 4541)
-    "dev-server")
-  (figwheel-sidecar.repl-api/cljs-repl "dev-server"))
+  (fw-repl/start-figwheel!
+   (assoc-in (fw-config/fetch-config)
+             [:data :figwheel-options :server-port] 4541)
+   "dev-server")
+  (fw-repl/cljs-repl "dev-server"))
 
 
 (defn start-ui!
   [& {:keys [ui-only?] :or {ui-only? false}}]
-  (let [dev-build-id (if ui-only? "dev-ui-only" "dev-ui")]
-   (figwheel-sidecar.repl-api/start-figwheel!
-     (figwheel-sidecar.config/fetch-config)
-     dev-build-id)
-   (figwheel-sidecar.repl-api/cljs-repl dev-build-id)))
+  (let [environment (if ui-only? "prod" "dev")
+        fig-config  (fw-config/fetch-config)]
+    (when ui-only? (info "Performing ui-only build..."))
+    (fw-repl/start-figwheel!
+     (set-closure-define fig-config "dev-ui" 'name-bazaar.ui.db.environment environment)
+     "dev-ui")
+    (fw-repl/cljs-repl "dev-ui")))
 
 
 (defn start-tests! []
-  (figwheel-sidecar.repl-api/start-figwheel!
-    (assoc-in (figwheel-sidecar.config/fetch-config)
-              [:data :figwheel-options :server-port] 4543)
-    "server-tests")
-  (figwheel-sidecar.repl-api/cljs-repl "server-tests"))
+  (fw-repl/start-figwheel!
+   (assoc-in (fw-config/fetch-config)
+             [:data :figwheel-options :server-port] 4543)
+   "server-tests")
+  (fw-repl/cljs-repl "server-tests"))
 
 
 (comment

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [cljsjs/react-dom "16.4.1-0"]
                  [cljsjs/react-infinite "0.13.0-0"]
                  [cljsjs/react-meta-tags "0.3.0-1"]
+                 [com.rpl/specter "1.1.1"]
                  [day8.re-frame/async-flow-fx "0.0.8"]
                  [day8.re-frame/forward-events-fx "0.0.5"]
                  [honeysql "0.9.3"]
@@ -19,10 +20,9 @@
                  [org.clojure/clojurescript "1.9.946"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [print-foo-cljs "2.0.3"]
-                 ;; TODO: On vbump, remove exclusion when new re-frame bumps reagent to 0.8.1+
-                 [re-frame "0.10.5" :exclusions [reagent]]
+                 [re-frame "0.10.5"]
+                 ;; Can be removed when re-frame vbump includes reagent 8.0.1+
                  [reagent "0.8.1"]
-                 ;; --------------------------------------------------------------------------
                  [re-frisk "0.5.4"]
                  [soda-ash "0.76.0"]
 
@@ -60,7 +60,9 @@
 
   :exclusions [[com.taoensso/encore]
                [org.clojure/clojure]
-               [org.clojure/clojurescript]]
+               [org.clojure/clojurescript]
+               ;; Can be removed when re-frame vbump includes reagent 8.0.1+
+               [reagent]]
 
   :plugins [[lein-auto "0.1.2"]
             [lein-cljsbuild "1.1.7"]
@@ -135,22 +137,6 @@
                                    :preloads [print.foo.preloads.devtools]
                                    :closure-defines {goog.DEBUG true
                                                      name-bazaar.ui.db.environment "dev"
-                                                     district0x.ui.history.pushroute-hosts "localhost"
-                                                     name-bazaar.ui.db.log-level "debug"}
-                                   :external-config {:devtools/config {:features-to-install :all}}}}
-
-                       ;; Development on client-side UI, with mainnet
-                       {:id "dev-ui-only"
-                        :source-paths ["src"]
-                        :figwheel {:on-jsload "name-bazaar.ui.core/mount-root"}
-                        :compiler {:main "name-bazaar.ui.core"
-                                   :output-to "resources/public/js/compiled/app.js"
-                                   :output-dir "resources/public/js/compiled/out-ui-only"
-                                   :asset-path "js/compiled/out-ui-only"
-                                   :source-map-timestamp true
-                                   :preloads [print.foo.preloads.devtools]
-                                   :closure-defines {goog.DEBUG true
-                                                     name-bazaar.ui.db.environment "prod"
                                                      district0x.ui.history.pushroute-hosts "localhost"
                                                      name-bazaar.ui.db.log-level "debug"}
                                    :external-config {:devtools/config {:features-to-install :all}}}}

--- a/src/name_bazaar/server/dev.cljs
+++ b/src/name_bazaar/server/dev.cljs
@@ -96,5 +96,3 @@
                    #'name-bazaar.server.generator/generator])
     (mount/start)
     pprint/pprint))
-
-(set! *main-cli-fn* -main)

--- a/src/name_bazaar/ui/db.cljs
+++ b/src/name_bazaar/ui/db.cljs
@@ -28,7 +28,7 @@
    :server-url "https://api.namebazaar.io"})
 
 (defn get-config [env-name]
-  (get {;"dev" development-config
+  (get {"dev" development-config
         "prod" production-config} env-name production-config))
 
 (def default-db


### PR DESCRIPTION
I originally was going to do a small pull request for an updated reagent so I could use React Fragments, but I ran into a bunch of issues when testing. This is the result.

I would like to test this better, so I would love to hear anyones input on how to ensure nothing breaks going forward.

- Version bumps for:
  - react
  - re-frame (exclusions for latest version of reagent)
  - reagent
  - re-frisk
  - honeysql

- Latest honeysql includes changes that were merged from madvas/honeysql

  - Removed exclusion, and is now using the latest

- changed source-paths for cljsbuilds dev(ui) and dev-server(server)

  - note: source-path should be treated as a set of classpaths,
    namespace resolution is determined at compile-time based on
    `(require)`'d namespaces. ie. if you don't want
    name-bazaar.server.* in your UI, then don't `(require)` them in
    your UI.

- Improved development environment

  - renamed build "dev" to "dev-ui"

  - added new build "dev-ui-only"

  - (start-ui!) can now receive the parameter :ui-only?. when true,
    it uses the :dev-ui-only build, which makes use of the mainnet
    for doing ui-only development.

    ex. (start-ui! :ui-only? true)

  - added 'dev' source-path to dev-server, and created new file
    ./dev/cljs/user.cljs

  - moved main entrypoint to cljs.user. Note that *main-cli-fn* is
    still set to name-bazaar.server.dev/-main

    - Using clojurescript's figwheel repl requires that reloaded
      development uses cljs.user as the main entrypoint for
      development.

  - added `redeploy` function, which is an asynchronous wrapper for
    name-bazaar.server.dev/redeploy.

    - This was causing the repl to timeout, so I turned it into an
      asynchronous call that prints to console when it has finished
      executing.

- Updated Readme with new development instructions