### PR TITLE
Don't loose focus on search

### DIFF
--- a/src/district0x/shared/utils.cljs
+++ b/src/district0x/shared/utils.cljs
@@ -11,7 +11,8 @@
     [cognitect.transit :as transit]
     [goog.string :as gstring]
     [goog.string.format]
-    [medley.core :as medley]))
+    [medley.core :as medley])
+  (:import [goog.async Debouncer]))
 
 (def json-reader (transit/reader :json))
 (def transit-writer (transit/writer :json))
@@ -228,3 +229,10 @@
 (defn evm-time->local-date-time [x]
   (when-let [dt (evm-time->date-time x)]
     (to-default-time-zone dt)))
+
+(defn debounce [f interval]
+  "Used for debouncing individual functions, not just effects. Ruthelessly stolen from:
+  https://www.martinklepsch.org/posts/simple-debouncing-in-clojurescript.html"
+  (let [dbnc (Debouncer. f interval)]
+    ;; We use apply here to support functions of various arities
+    (fn [& args] (.apply (.-fire dbnc) dbnc (to-array args)))))

--- a/src/name_bazaar/ui/components/main_panel.cljs
+++ b/src/name_bazaar/ui/components/main_panel.cljs
@@ -27,5 +27,5 @@
 (defn main-panel []
   (let [active-page (subscribe [:district0x/active-page])]
     (fn []
-      (let [{:keys [:handler :query-params]} @active-page]
-        ^{:key (str handler query-params)} [page handler]))))
+      (let [{:keys [:handler]} @active-page]
+        ^{:key (str handler)} [page handler]))))


### PR DESCRIPTION
There are two parts to this fix, one to stop React from remounting the main page component on every change to the query params. See this [StackOverflow](https://stackoverflow.com/questions/33299746/why-are-multi-methods-not-working-as-functions-for-reagent-re-frame) post for more information.

The second part is to add debouncing to the keyword lookup. We make use of the built in Google Closure debounce as described [here](https://www.martinklepsch.org/posts/simple-debouncing-in-clojurescript.html).

This is to solve issue #126.