### PR TITLE
Fix UI side smart contract load from files

### DIFF
--- a/src/name_bazaar/server/core.cljs
+++ b/src/name_bazaar/server/core.cljs
@@ -47,7 +47,8 @@
                             :ui {:reveal-period {:hours 48}
                                  :etherscan-url "https://etherscan.io"
                                  :cryptocompare-api-key "INSERT-YOUR-API-KEY-HERE"}}}
-         :smart-contracts {:contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts}
+         :smart-contracts {:contracts-build-path "./resources/public/contracts-build/"
+                           :contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts}
          :endpoints {:middlewares [logging-middlewares]}})
       (mount/start))
   (log/warn "System started" {:config (medley/dissoc-in @config [:emailer :private-key])}))

--- a/src/name_bazaar/server/dev.cljs
+++ b/src/name_bazaar/server/dev.cljs
@@ -76,7 +76,8 @@
                                      :ui          {:public-key             "192eb918a8a9996cf0233023b4d6b8d8071b7df392535ef72622136569abd4b8c009f302d9884d4ea54fd4714764fb44387"
                                                    :use-instant-registrar? true
                                                    :reveal-period          {:hours 48}}}}
-         :smart-contracts {:contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts
+         :smart-contracts {:contracts-build-path "./resources/public/contracts-build/"
+                           :contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts
                            :print-gas-usage? true
                            :auto-mining? true}})
       (mount/start)


### PR DESCRIPTION
We only use truffle and produce .json build files now. In the future the way to go is to use district.ui.smart-contracts module. It may not be worth pursuing this before all ui modules are migrated to new web3 though.