### PR TITLE
Server tests update

### DIFF
--- a/src/name_bazaar/ui/events.cljs
+++ b/src/name_bazaar/ui/events.cljs
@@ -192,7 +192,7 @@
                         :ens.record/owner owner}]
        (if (top-level-name? name)
          [:eth-registrar/transfer {:ens.record/label (name-label name)
-                                           :ens.record/owner owner}
+                                   :ens.record/owner owner}
           {:result-href (path-for :route.ens-record/detail {:ens.record/name name})
            :on-tx-receipt-n [[:ens.records/load [(namehash name)]
                              {:load-resolver? true}]

--- a/src/name_bazaar/ui/events/offerings_events.cljs
+++ b/src/name_bazaar/ui/events/offerings_events.cljs
@@ -656,7 +656,7 @@
       (conj
         (if (top-level-name? name)
           [:eth-registrar/transfer {:ens.record/label (name-label name)
-                                            :ens.record/owner owner}]
+                                    :ens.record/owner owner}]
           [:ens/set-owner {:ens.record/name name
                            :ens.record/owner owner}])
         {:result-href (path-for :route.offerings/detail {:offering/address owner})

--- a/test/server/name_bazaar/smart_contract_altering_tests.cljs
+++ b/test/server/name_bazaar/smart_contract_altering_tests.cljs
@@ -1,17 +1,15 @@
 (ns server.name-bazaar.smart-contract-altering-tests
   (:require
     [bignumber.core :as bn]
+    [cljs.core.async :refer [<! go]]
     [cljs-time.coerce :refer [to-epoch from-long]]
     [cljs-time.core :as t]
-    [cljs-web3.core :as web3]
-    [cljs-web3.eth :as web3-eth]
-    [cljs-web3.evm :as web3-evm]
-    [cljs.nodejs :as nodejs]
+    [cljs-web3-next.eth :as web3-eth]
+    [cljs-web3-next.evm :as web3-evm]
+    [cljs-web3-next.utils :refer [to-wei]]
     [cljs.test :refer-macros [deftest is testing run-tests use-fixtures async]]
     [district.server.smart-contracts :refer [contract-address]]
     [district.server.web3 :refer [web3]]
-    [district0x.shared.utils :as d0x-shared-utils :refer [eth->wei wei->eth]]
-    [mount.core :as mount]
     [name-bazaar.server.contracts-api.auction-offering :as auction-offering]
     [name-bazaar.server.contracts-api.auction-offering-factory :as auction-offering-factory]
     [name-bazaar.server.contracts-api.buy-now-offering :as buy-now-offering]
@@ -20,348 +18,369 @@
     [name-bazaar.server.contracts-api.offering :as offering]
     [name-bazaar.server.contracts-api.offering-registry :as offering-registry]
     [name-bazaar.server.contracts-api.registrar :as registrar]
-    [name-bazaar.server.contracts-api.used-by-factories :as used-by-factories]
     [name-bazaar.shared.smart-contracts]
-    [print.foo :include-macros true]))
-
-(def namehash (aget (js/require "eth-ens-namehash") "hash"))
-(def sha3 (comp (partial str "0x") (aget (js/require "js-sha3") "keccak_256")))
-
-(defn now []
-  (from-long (* (:timestamp (web3-eth/get-block @web3 (web3-eth/block-number @web3))) 1000)))
+    [print.foo :include-macros true]
+    [server.name-bazaar.utils :refer [after-test before-test get-balance namehash now sha3]]))
 
 (use-fixtures
-  :each
-  {:before
-   (fn []
-     (-> (mount/with-args
-           {:web3 {:port 8549}
-            :smart-contracts {:contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts
-                              :auto-mining? true}})
-         (mount/only [#'district.server.web3
-                      #'district.server.smart-contracts/smart-contracts])
-         (mount/start)))
-   :after
-   (fn []
-     (mount/stop)
-     (async done (js/setTimeout #(done) 500)))})
+  :each {:before before-test
+         :after after-test})
 
 (deftest offering-reclaiming-buy-now-tld
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
+                                                                               :offering/price (to-wei @web3 0.1 :ether)}
+                                                                              {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+        (testing "Registering name"
+          (is register-tx))
 
-    (testing "Making an instant offer"
-      (let [tx-hash (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
-                                                                :offering/price (eth->wei 0.1)}
-                                                               {:from addr1})]
-        (is tx-hash)
+        (testing "Making an instant offer"
+          (is create-offering-tx))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-          (testing "Transferring ownership to the offering"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr1})))
+        (testing "Transferring ownership to the offering"
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr1}))]
+            (is tx)))
 
-          (testing "Ensuring offering gets the registration"
-            (is (= offering (registrar/registration-owner {:ens.record/label "abc"}))))
-          (testing "For Buy Now offering, original owner can reclaim ENS name ownership (for TLD also registration ownership)"
-            (is (buy-now-offering/reclaim-ownership! offering {:from addr1})))
+        (testing "Ensuring offering gets the registration"
+          (is (= offering (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
-          (testing "The name ownership must be transferred back to owner"
-            (is (= addr1 (ens/owner {:ens.record/node (namehash "abc.eth")}))))
-          (testing "Ensuring the new owner gets back his registration"
-            (is (= addr1 (registrar/registration-owner {:ens.record/label "abc"})))))))))
+        (testing "For Buy Now offering, original owner can reclaim name ownership in .eth registrar and ENS"
+          (let [tx (<! (buy-now-offering/reclaim-ownership! offering {:from addr1}))]
+            (is tx)))
+
+        (testing "The name ownership must be transferred back to owner"
+          (is (= addr1 (<! (ens/owner {:ens.record/node (namehash "abc.eth")})))))
+
+        (testing "Ensuring the new owner gets back his registration"
+          (is (= addr1 (<! (registrar/registration-owner {:ens.record/label "abc"}))))))
+      (done))))
 
 
 (deftest offering-reclaiming-buy-now-subdomain
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "tld"}
+                                                 {:from addr1}))
+            set-subnode-owner-tx (<! (ens/set-subnode-owner!
+                                       {:ens.record/label "theirsub"
+                                        :ens.record/node "tld.eth"
+                                        :ens.record/owner addr2}
+                                       {:from addr1}))
+            create-offering-tx (<! (buy-now-offering-factory/create-offering!
+                                     {:offering/name "theirsub.tld.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)}
+                                     {:from addr2}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+        (is register-tx)
+        (is set-subnode-owner-tx)
 
-    (is (registrar/register! {:ens.record/label "tld"}
-                             {:from addr1}))
-    (is (ens/set-subnode-owner!
-          {:ens.record/label "theirsub"
-           :ens.record/node "tld.eth"
-           :ens.record/owner addr2}
-          {:from addr1}))
-    (testing "The name ownership must be transferred to the user"
-      (is (= addr2 (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))
-    (testing "Making an instant offer"
-      (let [tx-hash (buy-now-offering-factory/create-offering! {:offering/name "theirsub.tld.eth"
-                                                                :offering/price (eth->wei 0.1)}
-                                                               {:from addr2})]
-        (is tx-hash)
+        (testing "The name ownership must be transferred to the user"
+          (is (= addr2 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "theirsub.tld.eth")
-                                                                  :from-block 0
-                                                                  :owner addr2})]
+        (testing "Making an instant offer"
+            (is create-offering-tx)
 
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-          (testing "Transferring ownership to the offering"
-            (is (ens/set-owner! {:ens.record/node (namehash "theirsub.tld.eth")
-                                 :ens.record/owner offering}
-                                {:from addr2})))
+        (testing "Transferring ownership to the offering"
+          (let [tx (<! (ens/set-owner! {:ens.record/node (namehash "theirsub.tld.eth")
+                                        :ens.record/owner offering}
+                                       {:from addr2}))]
+            (is tx)))
 
-          (testing "The name ownership must be transferred to the offering"
-            (is (= offering (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))
+        (testing "The name ownership must be transferred to the offering"
+          (is (= offering (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))
 
-          (testing "For Buy Now offering, original owner can reclaim ENS name ownership"
-            (is (buy-now-offering/reclaim-ownership! offering
-                                                     {:from addr2})))
+        (testing "For Buy Now offering, original owner can reclaim ENS name ownership"
+          (let [tx (<! (buy-now-offering/reclaim-ownership! offering
+                                                            {:from addr2}))]
+            (is tx)))
 
-          (testing "The name ownership must be transferred back to owner"
-            (is (= addr2 (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))))))
-
+        (testing "The name ownership must be transferred back to owner"
+          (is (= addr2 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))))
+      (done))))
 
 
 (deftest offering-reclaiming-auction-tld
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+        (testing "Registering name"
+          (is register-tx))
 
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "abc.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 2)))
-                       :auction-offering/extension-duration 0
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr1})]
-        (is tx-hash)
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
-          (when offering
-            (testing "Transferring ownership to the offering"
-              (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                       {:from addr1})))
+        (when offering
+          (testing "Transferring ownership to the offering"
+            (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                               :ens.record/owner offering}
+                                              {:from addr1}))]
+              (is tx)))
 
-            (testing "Ensuring offering gets the registration"
-              (is (= offering (registrar/registration-owner {:ens.record/label "abc"}))))
-            (testing "For Buy Now offering, original owner can reclaim ENS name ownership (for TLD also registration ownership)"
-              (is (buy-now-offering/reclaim-ownership! offering {:from addr1})))
+          (testing "Ensuring offering gets the registration"
+            (is (= offering (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
-            (testing "The name ownership must be transferred back to owner"
-              (is (= addr1 (ens/owner {:ens.record/node (namehash "abc.eth")}))))
-            (testing "Ensuring the new owner gets back his registration"
-              (is (= addr1 (registrar/registration-owner {:ens.record/label "abc"}))))))))))
+          (testing "For Buy Now offering, original owner can reclaim name ownership in .eth registrar and ENS"
+            (let [tx (<! (buy-now-offering/reclaim-ownership! offering {:from addr1}))]
+              (is tx)))
+
+          (testing "The name ownership must be transferred back to owner"
+            (is (= addr1 (<! (ens/owner {:ens.record/node (namehash "abc.eth")})))))
+
+          (testing "Ensuring the new owner gets back his registration"
+            (is (= addr1 (<! (registrar/registration-owner {:ens.record/label "abc"})))))))
+      (done))))
 
 
 (deftest offering-reclaiming-auction-subdomain
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "tld"}
+                                                 {:from addr1}))
+            set-subnode-owner-tx (<! (ens/set-subnode-owner!
+                                       {:ens.record/label "theirsub"
+                                        :ens.record/node "tld.eth"
+                                        :ens.record/owner addr2}
+                                       {:from addr1}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "theirsub.tld.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr2}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (is (registrar/register! {:ens.record/label "tld"}
-                             {:from addr1}))
+        (is register-tx)
+        (is set-subnode-owner-tx)
 
-    (is (ens/set-subnode-owner!
-          {:ens.record/label "theirsub"
-           :ens.record/node "tld.eth"
-           :ens.record/owner addr2}
-          {:from addr1}))
+        (testing "The name ownership must be transferred to the user"
+          (is (= addr2 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))
 
-    (testing "The name ownership must be transferred to the user"
-      (is (= addr2 (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "theirsub.tld.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 2)))
-                       :auction-offering/extension-duration 0
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr2})]
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-        (is tx-hash)
+        (when offering
+          (testing "Transferring ownership to the offering"
+            (let [tx (<! (ens/set-subnode-owner! {:ens.record/label "theirsub"
+                                                  :ens.record/node "tld.eth"
+                                                  :ens.record/owner offering}
+                                                 {:from addr1}))]
+              (is tx)))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "theirsub.tld.eth")
-                                                                  :from-block 0
-                                                                  :owner addr2})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
-          (when offering
-            (testing "Transferring ownership to the offering"
-              (is (ens/set-subnode-owner! {:ens.record/label "theirsub"
-                                           :ens.record/node "tld.eth"
-                                           :ens.record/owner offering}
-                                          {:from addr1})))
+          (testing "The name ownership must be transferred to the offering"
+            (is (= offering (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))
 
-            (testing "The name ownership must be transferred to the offering"
-              (is (= offering (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))
+          (testing "For Buy Now offering, original owner can reclaim ENS name ownership"
+            (let [tx (<! (buy-now-offering/reclaim-ownership! offering {:from addr2}))]
+              (is tx)))
 
-            (testing "For Buy Now offering, original owner can reclaim ENS name ownership"
-              (is (buy-now-offering/reclaim-ownership! offering {:from addr2})))
-
-            (testing "The name ownership must be transferred back to owner"
-              (is (= addr2 (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))))))))
+          (testing "The name ownership must be transferred back to owner"
+            (is (= addr2 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))))
+      (done))))
 
 
 (deftest offering-reclaiming-auction-tld-emergency
-  (let [[addr0 addr1 addr2 addr3 addr4] (web3-eth/accounts @web3)]
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3 addr4] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+        (testing "Registering name"
+          (is register-tx))
+    
+        (testing "Offering the name for a bid"
+            (is create-offering-tx))
 
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "abc.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 2)))
-                       :auction-offering/extension-duration 0
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr1})]
-        (is tx-hash)
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "Transferring ownership to the offering"
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr1}))]
+            (is tx)))
 
-          (testing "Transferring ownership to the offering"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr1})))
+        (testing "Ensuring offering gets the registration"
+          (is (= offering (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
-          (testing "Ensuring offering gets the registration"
-            (is (= offering (registrar/registration-owner {:ens.record/label "abc"}))))
+        (testing "Can place a proper bid"
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr4}))]
+            (is tx)))
 
-          (testing "Can place a proper bid"
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value (web3/to-wei 0.1 :ether)
-                                        :from addr4})))
+        (let [balance-of-4 (<! (get-balance addr4))]
+          (testing "For Buy Now offering, original owner can reclaim name ownership in .eth registrar and ENS"
+            (let [tx (<! (buy-now-offering/reclaim-ownership! offering {:from addr0}))]
+              (is tx)))
 
-          (let [balance-of-4 (web3-eth/get-balance @web3 addr4)]
-            (testing "For Buy Now offering, original owner can reclaim ENS name ownership (for TLD also registration ownership)"
-              (is (buy-now-offering/reclaim-ownership! offering {:from addr0})))
+          (testing "The name ownership must be transferred back to owner"
+            (is (= addr1 (<! (ens/owner {:ens.record/node (namehash "abc.eth")})))))
 
-            (testing "The name ownership must be transferred back to owner"
-              (is (= addr1 (ens/owner {:ens.record/node (namehash "abc.eth")}))))
-            (testing "Ensuring the new owner gets back his registration"
-              (is (= addr1 (registrar/registration-owner {:ens.record/label "abc"}))))
+          (testing "Ensuring the new owner gets back his registration"
+            (is (= addr1 (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
-            (testing "User who was overbid, can successfully withdraw funds from auction offering."
-              (is (auction-offering/withdraw! {:offering offering
-                                               :address addr4}
-                                              {:from addr4}))
-              (is (< (- (bn/+ balance-of-4 (web3/to-wei 0.1 :ether))
-                        (web3-eth/get-balance @web3 addr4))
-                     100000)))))))))
+          (testing "User who was overbid, can successfully withdraw funds from auction offering."
+            (let [tx (<! (auction-offering/withdraw! {:offering offering
+                                                      :address addr4}
+                                                     {:from addr4}))]
+              (is tx))
+            (is (< (- (bn/+ balance-of-4 (bn/number (to-wei @web3 0.1 :ether)))
+                      (<! (get-balance addr4)))
+                   100000)))))
+      (done))))
 
 
 (deftest offering-editing-buy-now
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (buy-now-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (testing "Making an instant offer"
-      (let [tx-hash (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
-                                                                :offering/price (eth->wei 0.1)}
-                                                               {:from addr1})]
-        (is tx-hash)
+        (testing "Registering name"
+          (is register-tx))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "Making an instant offer"
+          (is create-offering-tx)
 
-          (testing "Transferring ownership to the offering"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr1})))
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-          (testing "Offering can be successfully edited by original owner, throws error if different address tries to edit"
-            (is (thrown? :default (buy-now-offering/set-settings! {:offering/address offering
-                                                                   :offering/price (eth->wei 0.2)}
-                                                                  {:from addr2}))))
-          (testing "Updating price"
-            (is (buy-now-offering/set-settings! {:offering/address offering
-                                                 :offering/price (eth->wei 0.2)}
-                                                {:from addr1})))
-          (testing "The price is updated"
-            (is (= (eth->wei 0.2) (str (:offering/price (offering/get-offering offering)))))))))))
+        (testing "Transferring ownership to the offering"
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr1}))]
+            (is tx)))
+
+        (testing "Offering can be successfully edited by original owner, throws error if different address tries to edit"
+          (let [tx (<! (buy-now-offering/set-settings! {:offering/address offering
+                                                        :offering/price (to-wei @web3 0.2 :ether)}
+                                                       {:from addr2}))]
+            (is (nil? tx))))
+
+        (testing "Updating price"
+          (let [tx (<! (buy-now-offering/set-settings! {:offering/address offering
+                                                        :offering/price (to-wei @web3 0.2 :ether)}
+                                                       {:from addr1}))]
+            (is tx)))
+
+        (testing "The price is updated"
+          (is (= (to-wei @web3 0.2 :ether) (str (:offering/price (<! (offering/get-offering offering)))))))))
+      (done))))
+
 
 (deftest offering-editing-auction
-  (let [[addr0 addr1 addr2 addr3 addr4] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3 addr4] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (t/plus (<!(now))(t/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "abc.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 2)))
-                       :auction-offering/extension-duration 0
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr1})]
+        (testing "Registering name"
+          (is register-tx))
 
-        (is tx-hash)
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-          (testing "Transferring ownership to the offering"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr1})))
+        (testing "Transferring ownership to the offering"
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr1}))]
+            (is tx)))
 
+        (let [t0 (to-epoch (t/plus (<! (now)) (t/weeks 4)))]
+          (testing "Auction offering can be edited"
+            (let [tx (<! (auction-offering/set-settings!
+                           {:offering/address offering
+                            :offering/price (to-wei @web3 0.2 :ether)
+                            :auction-offering/end-time t0
+                            :auction-offering/extension-duration 10000
+                            :auction-offering/min-bid-increase (to-wei @web3 0.2 :ether)}
+                           {:from addr1}))]
+              (is tx)))
 
-          (let [t0 (to-epoch (t/plus (now) (t/weeks 4)))]
-            (testing "Auction offering can be edited"
-              (is (auction-offering/set-settings!
-                    {:offering/address offering
-                     :offering/price (eth->wei 0.2)
-                     :auction-offering/end-time t0
-                     :auction-offering/extension-duration 10000
-                     :auction-offering/min-bid-increase (web3/to-wei 0.2 :ether)}
-                    {:from addr1})))
+          (testing "State of the auction offering is correct"
+            (is (= {:auction-offering/end-time (js/Math.floor t0),
+                    :auction-offering/extension-duration 10000,
+                    :auction-offering/min-bid-increase 200000000000000000}
+                   (select-keys (<! (auction-offering/get-auction-offering offering))
+                                [:auction-offering/end-time
+                                 :auction-offering/extension-duration
+                                 :auction-offering/min-bid-increase])))))
 
+        (testing "The price is updated"
+          (is (= (to-wei @web3 0.2 :ether) (str (:offering/price (<! (offering/get-offering offering)))))))
 
-            (testing "State of the auction offering is correct"
-              (is (= {:auction-offering/end-time (js/Math.floor t0),
-                      :auction-offering/extension-duration 10000,
-                      :auction-offering/min-bid-increase 200000000000000000}
-                     (select-keys (auction-offering/get-auction-offering offering)
-                                  [:auction-offering/end-time
-                                   :auction-offering/extension-duration
-                                   :auction-offering/min-bid-increase])))))
+        (testing "Can place a proper bid"
+          (is (auction-offering/bid! {:offering/address offering}
+                                     {:value (to-wei @web3 0.4 :ether)
+                                      :from addr4})))
 
-          (testing "The price is updated"
-            (is (= (eth->wei 0.2) (str (:offering/price (offering/get-offering offering))))))
-
-          (testing "Can place a proper bid"
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value (web3/to-wei 0.4 :ether)
-                                        :from addr4})))
-
-          (testing "Auction offering can be edited only when has 0 bids, throws error if otherwise."
-            (is (thrown? :default (auction-offering/set-settings!
-                                    {:offering/address offering
-                                     :offering/price (eth->wei 0.8)
-                                     :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 8)))
-                                     :auction-offering/extension-duration 20000
-                                     :auction-offering/min-bid-increase (web3/to-wei 0.3 :ether)}
-                                    {:from addr1})))))))))
+        (testing "Auction offering can be edited only when has 0 bids, throws error if otherwise."
+          (let [tx (<! (auction-offering/set-settings!
+                         {:offering/address offering
+                          :offering/price (to-wei @web3 0.8 :ether)
+                          :auction-offering/end-time (to-epoch (t/plus (<! (now)) (t/weeks 8)))
+                          :auction-offering/extension-duration 20000
+                          :auction-offering/min-bid-increase (to-wei @web3 0.3 :ether)}
+                         {:from addr1}))]
+            (is (nil? tx)))))
+      (done))))

--- a/test/server/name_bazaar/smart_contract_ext_tests.cljs
+++ b/test/server/name_bazaar/smart_contract_ext_tests.cljs
@@ -1,17 +1,16 @@
 (ns server.name-bazaar.smart-contract-ext-tests
   (:require
     [bignumber.core :as bn]
+    [cljs.core.async :refer [<! go]]
     [cljs-time.coerce :refer [to-epoch from-long]]
     [cljs-time.core :as t]
-    [cljs-web3.core :as web3]
-    [cljs-web3.eth :as web3-eth]
-    [cljs-web3.evm :as web3-evm]
-    [cljs.nodejs :as nodejs]
+    [cljs-web3-next.eth :as web3-eth]
+    [cljs-web3-next.evm :as web3-evm]
+    [cljs-web3-next.utils :refer [to-wei]]
     [cljs.test :refer-macros [deftest is testing run-tests use-fixtures async]]
+    [clojure.string :as string]
     [district.server.smart-contracts :refer [contract-address]]
     [district.server.web3 :refer [web3]]
-    [district0x.shared.utils :as d0x-shared-utils :refer [eth->wei wei->eth]]
-    [mount.core :as mount]
     [name-bazaar.server.contracts-api.auction-offering :as auction-offering]
     [name-bazaar.server.contracts-api.auction-offering-factory :as auction-offering-factory]
     [name-bazaar.server.contracts-api.buy-now-offering :as buy-now-offering]
@@ -22,312 +21,344 @@
     [name-bazaar.server.contracts-api.registrar :as registrar]
     [name-bazaar.server.contracts-api.used-by-factories :as used-by-factories]
     [name-bazaar.shared.smart-contracts]
-    [print.foo :include-macros true]))
-
-(def namehash (aget (js/require "eth-ens-namehash") "hash"))
-(def sha3 (comp (partial str "0x") (aget (js/require "js-sha3") "keccak_256")))
-
-(defn now []
-  (from-long (* (:timestamp (web3-eth/get-block @web3 (web3-eth/block-number @web3))) 1000)))
+    [print.foo :include-macros true]
+    [server.name-bazaar.utils :refer [after-test before-test get-balance namehash now sha3]]))
 
 (use-fixtures
-  :each
-  {:before
-   (fn []
-     (-> (mount/with-args
-           {:web3 {:port 8549}
-            :smart-contracts {:contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts
-                              :auto-mining? true}})
-         (mount/only [#'district.server.web3
-                      #'district.server.smart-contracts/smart-contracts])
-         (mount/start)))
-   :after
-   (fn []
-     (mount/stop)
-     (async done (js/setTimeout #(done) 500)))})
+  :each {:before before-test
+         :after after-test})
 
 (deftest create-auction-offering
-  (let [[addr0 addr1 addr2] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr0})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr0}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr0}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (let [tx-hash (auction-offering-factory/create-offering!
-                    {:offering/name "abc.eth"
-                     :offering/price (eth->wei 0.1)
-                     :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 2)))
-                     :auction-offering/extension-duration 0
-                     :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                    {:from addr0})]
+        (testing "Registering name"
+          (is register-tx))
 
-      (testing "Offering the name for a bid"
-        (is tx-hash))
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-      (let [{{:keys [:offering]} :args}
-            (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                :from-block 0
-                                                                :owner addr0})]
-        (testing "on-offering event should fire"
+        (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
         (testing "Can't place a bid before ownership transfer"
-          (is (thrown? :default (auction-offering/bid! {:offering/address offering}
-                                                       {:value (web3/to-wei 0.1 :ether)
-                                                        :from addr1}))))
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr1}))]
+            (is (nil? tx))))
+
         (testing "Transferring ownership to the offer"
-          (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                   {:from addr0})))
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr0}))]
+            (is tx)))
+
         (testing "Can place a proper bid"
-          (is (auction-offering/bid! {:offering/address offering}
-                                     {:value (web3/to-wei 0.1 :ether)
-                                      :from addr1})))
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr1}))]
+            (is tx)))
+
         (testing "Correct increase of the bid is accepted"
-          (is (auction-offering/bid! {:offering/address offering}
-                                     {:value (web3/to-wei 0.2 :ether)
-                                      :from addr2})))
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.2 :ether)
+                                               :from addr2}))]
+            (is tx)))
+
         (testing "If user has bid before, he needs to send the whole amount again in order to make a new bid"
-          (is (auction-offering/bid! {:offering/address offering}
-                                     {:value (web3/to-wei 0.3 :ether)
-                                      :from addr1})))
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.3 :ether)
+                                               :from addr1}))]
+            (is tx)))
+
         (testing "State of the auction offering is correct"
           (is (= {:auction-offering/min-bid-increase 100000000000000000
-                  :auction-offering/winning-bidder addr1
-                  :auction-offering/bid-count 3}
-                 (select-keys (auction-offering/get-auction-offering offering)
+                  :auction-offering/winning-bidder   (string/lower-case addr1)
+                  :auction-offering/bid-count        3}
+                 (select-keys (<! (auction-offering/get-auction-offering offering))
                               [:auction-offering/min-bid-increase
                                :auction-offering/winning-bidder
-                               :auction-offering/bid-count]))))))))
+                               :auction-offering/bid-count])))))
+      (done))))
 
 
 (deftest create-subdomain-auction-offering
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)
-        t0 (to-epoch (t/plus (now) (t/weeks 2)))]
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            t0 (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+            register-tx (<! (registrar/register! {:ens.record/label "tld"}
+                                                 {:from addr0}))
+            set-subnode-owner-tx (<! (ens/set-subnode-owner! {:ens.record/label "theirsub"
+                                                              :ens.record/node "tld.eth"
+                                                              :ens.record/owner addr1}
+                                                             {:from addr0}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "theirsub.tld.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time t0
+                                      :auction-offering/extension-duration (t/in-seconds (t/days 4))
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+        (is register-tx)
+        (is set-subnode-owner-tx)
+        (is (= addr1 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))
 
-    (is (registrar/register! {:ens.record/label "tld"}
-                             {:from addr0}))
-    (is (ens/set-subnode-owner! {:ens.record/label "theirsub"
-                                 :ens.record/node "tld.eth"
-                                 :ens.record/owner addr1}
-                                {:from addr0}))
-    #_(is (= addr1 (ens/owner {:ens.record/node (namehash
-                                                  "theirsub.tld.eth")})))
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "theirsub.tld.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time t0
-                       :auction-offering/extension-duration (t/in-seconds (t/days 4))
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr1})]
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "theirsub.tld.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-          (testing "Can't place a bid before ownership transfer"
-            (is (thrown? :default (auction-offering/bid! {:offering/address offering}
-                                                         {:value (web3/to-wei 0.1 :ether)
-                                                          :from addr1}))))
+        (testing "Can't place a bid before ownership transfer"
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr1}))]
+            (is (nil? tx))))
 
-          (testing "Transferring ownership to the offer"
-            (is (ens/set-subnode-owner! {:ens.record/label "theirsub"
-                                         :ens.record/node "tld.eth"
-                                         :ens.record/owner offering}
-                                        {:from addr0})))
+        (testing "Transferring ownership to the offer"
+          (let [tx (<! (ens/set-subnode-owner! {:ens.record/label "theirsub"
+                                                :ens.record/node "tld.eth"
+                                                :ens.record/owner offering}
+                                               {:from addr0}))]
+            (is tx)))
 
-          (testing "Can place a proper bid"
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value (web3/to-wei 0.1 :ether)
-                                        :from addr2})))
+        (testing "Can place a proper bid"
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr2}))]
+            (is tx)))
 
-          (web3-evm/increase-time! @web3 [(t/in-seconds (t/days 13))])
+        (<! (web3-evm/increase-time @web3 (t/in-seconds (t/days 13))))
 
-          (let [balance-of-2 (web3-eth/get-balance @web3 addr2)]
-            (testing "Can place a bid"
-              (is (auction-offering/bid! {:offering/address offering}
-                                         {:value (web3/to-wei 0.3 :ether)
-                                          :from addr3})))
+        (let [balance-of-2 (<! (get-balance addr2))]
+          (testing "Can place a bid"
+            (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                {:value (to-wei @web3 0.3 :ether)
+                                                 :from addr3}))]
+              (is tx)))
 
-            (testing "User who was overbid, should have his funds back from auction offering."
+          (testing "User who was overbid, should have his funds back from auction offering."
+            (is (< (- (bn/+ balance-of-2 (bn/number (to-wei @web3 0.1 :ether)))
+                      (<! (get-balance addr2)))
+                   100000)))
 
-              (is (< (- (bn/+ balance-of-2 (web3/to-wei 0.1 :ether))
-                        (web3-eth/get-balance @web3 addr2))
-                     100000)))
+          (testing "Nothing to withdraw if return transfer succeeded on overbid."
+            (let [withdraw-tx (<! (auction-offering/withdraw! {:offering offering
+                                                               :address addr2}
+                                                              {:from addr2}))]
+              (is withdraw-tx)
+              (is (< (- (bn/+ balance-of-2 (bn/number (to-wei @web3 0.1 :ether)))
+                        (<! (get-balance addr2)))
+                     100000))))
 
-            (testing "Nothing to withdraw if return transfer succeeded on overbid."
-              (is (auction-offering/withdraw! {:offering offering
-                                               :address addr2}
-                                              {:from addr2}))
-              (is (< (- (bn/+ balance-of-2 (web3/to-wei 0.1 :ether))
-                        (web3-eth/get-balance @web3 addr2))
-                     100000)))
-
-            (testing "State of the auction offering is correct"
-              (is (< (- (:auction-offering/end-time (auction-offering/get-auction-offering offering))
-                        t0
-                        (t/in-seconds (t/days 3)))
-                     10)))                                  ;;threashold on operations
-            ))))))
+          (testing "State of the auction offering is correct"
+            (is (< (- (:auction-offering/end-time (<! (auction-offering/get-auction-offering offering)))
+                      t0
+                      (t/in-seconds (t/days 3)))
+                   100))) ;; threshold on operations
+          ))
+      (done))))
 
 
 (deftest subdomain-auction-withdraw
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)
-        t0 (to-epoch (t/plus (now) (t/weeks 2)))]
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            t0 (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+            register-tx (<! (registrar/register! {:ens.record/label "tld"}
+                                                 {:from addr0}))
+            set-subnode-owner-tx (<! (ens/set-subnode-owner! {:ens.record/label "theirsub"
+                                                              :ens.record/node "tld.eth"
+                                                              :ens.record/owner addr1}
+                                                             {:from addr0}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "theirsub.tld.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time t0
+                                      :auction-offering/extension-duration (t/in-seconds (t/days 4))
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+        (is register-tx)
+        (is set-subnode-owner-tx)
 
-    (is (registrar/register! {:ens.record/label "tld"}
-                             {:from addr0}))
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-    (is (ens/set-subnode-owner! {:ens.record/label "theirsub"
-                                 :ens.record/node "tld.eth"
-                                 :ens.record/owner addr1}
-                                {:from addr0}))
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "theirsub.tld.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time t0
-                       :auction-offering/extension-duration (t/in-seconds (t/days 4))
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr1})]
+        (testing "Transferring ownership to the offer"
+          (let [tx (<! (ens/set-subnode-owner! {:ens.record/label "theirsub"
+                                                :ens.record/node "tld.eth"
+                                                :ens.record/owner offering}
+                                               {:from addr0}))]
+            (is tx)))
 
-        (is tx-hash)
+        (testing "Can place a proper bid"
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr2}))]
+            (is tx)))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "theirsub.tld.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (<! (web3-evm/increase-time @web3 (t/in-seconds (t/days 13))))
 
-          (testing "Transferring ownership to the offer"
-            (is (ens/set-subnode-owner! {:ens.record/label "theirsub"
-                                         :ens.record/node "tld.eth"
-                                         :ens.record/owner offering}
-                                        {:from addr0})))
+        (let [balance-of-2 (<! (get-balance addr2))]
+          (testing "Can place a bid"
+            (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                {:value (to-wei @web3 0.3 :ether)
+                                                 :from addr3}))]
+              (is tx)))
 
-          (testing "Can place a proper bid"
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value (web3/to-wei 0.1 :ether)
-                                        :from addr2})))
+          (testing "Emergency address can withdraw funds to a user's address on his behalf."
+            (let [tx (<! (auction-offering/withdraw! {:offering offering
+                                                      :address addr2}
+                                                     {:from addr0}))]
+              (is tx))
 
-          (web3-evm/increase-time! @web3 [(t/in-seconds (t/days 13))])
+            (is (< (- (bn/+ balance-of-2 (bn/number (to-wei @web3 0.1 :ether)))
+                      (<! (get-balance addr2)))
+                   100000)))
 
-          (let [balance-of-2 (web3-eth/get-balance @web3 addr2)]
-            (testing "Can place a bid"
-              (is (auction-offering/bid! {:offering/address offering}
-                                         {:value (web3/to-wei 0.3 :ether)
-                                          :from addr3})))
+          (testing "user can't withdraw twice."
+            (let [tx (<! (auction-offering/withdraw! {:offering offering
+                                                      :address addr2}
+                                                     {:from addr2}))]
+              (is tx))
+            (is (< (- (bn/+ balance-of-2 (bn/number (to-wei @web3 0.1 :ether)))
+                      (<! (get-balance addr2)))
+                   100000)))
 
-            (testing "Emergency address can withdraw funds to a user's address on his behalf."
-              (is (auction-offering/withdraw! {:offering offering
-                                               :address addr2}
-                                              {:from addr0}))
+          (testing "State of the auction offering is correct"
+            (is (< (- (:auction-offering/end-time (<! (auction-offering/get-auction-offering offering)))
+                      t0
+                      (t/in-seconds (t/days 3)))
+                   100))) ;; threshold on operations
+          ))
+      (done))))
 
-              (is (< (- (bn/+ balance-of-2 (web3/to-wei 0.1 :ether))
-                        (web3-eth/get-balance @web3 addr2))
-                     100000)))
-
-            (testing "user can't withdraw twice."
-              (is (auction-offering/withdraw! {:offering offering
-                                               :address addr2}
-                                              {:from addr2}))
-
-              (is (< (- (bn/+ balance-of-2 (web3/to-wei 0.1 :ether))
-                        (web3-eth/get-balance @web3 addr2))
-                     100000)))
-
-            (testing "State of the auction offering is correct"
-              (is (< (- (:auction-offering/end-time (auction-offering/get-auction-offering offering))
-                        t0
-                        (t/in-seconds (t/days 3)))
-                     10)))                                  ;;threashold on operations
-            ))))))
 
 (deftest freezed-auction-offering-behaviour
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (t/plus (<! (now)) (t/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (testing "Offering the name for a bid"
-      (let [tx-hash (auction-offering-factory/create-offering!
-                      {:offering/name "abc.eth"
-                       :offering/price (eth->wei 0.1)
-                       :auction-offering/end-time (to-epoch (t/plus (now) (t/weeks 2)))
-                       :auction-offering/extension-duration 0
-                       :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                      {:from addr1})]
-        (is tx-hash)
+        (testing "Registering name"
+          (is register-tx))
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-          (testing "Transferring ownership to the offer"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr1})))
-          (testing "Emergency multisig can pause the registry"
-            (is (offering-registry/emergency-pause! {:from addr0})))
-          (testing "Can't place a bid, while the registry is paused "
-            (is (thrown? :default (auction-offering/bid! {:offering/address offering}
-                                                         {:value (web3/to-wei 0.1 :ether)
-                                                          :from addr2}))))
-          (testing "Emergency multisig can release the registry"
-            (is (offering-registry/emergency-release! {:from addr0})))
-          (testing "Can place a bid, whe it's resumed "
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value (web3/to-wei 0.1 :ether)
-                                        :from addr2})))
-          (web3-evm/increase-time! @web3 [(t/in-seconds (t/days 15))])
+        (testing "On-offering event should fire"
+          (is (not (nil? offering))))
 
-          (testing "Emergency multisig can pause the registry"
-            (is (offering-registry/emergency-pause! {:from addr0})))
-          (testing "Finalizing is not possible on frozen registry"
-            (is (thrown? :default (auction-offering/finalize! offering {:from addr1}))))
-          (testing "Emergency multisig can release the registry"
-            (is (offering-registry/emergency-release! {:from addr0})))
-          (testing "Finalizing works when it's time"
-            (is (auction-offering/finalize! offering {:from addr1}))))))))
+        (testing "Transferring ownership to the offer"
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr1}))]
+            (is tx)))
+
+        (testing "Emergency multisig can pause the registry"
+          (let [tx (<! (offering-registry/emergency-pause! {:from addr0}))]
+            (is tx)))
+
+        (testing "Can't place a bid, while the registry is paused "
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr2}))]
+            (is (nil? tx))))
+
+        (testing "Emergency multisig can release the registry"
+          (let [tx (<! (offering-registry/emergency-release! {:from addr0}))]))
+
+        (testing "Can place a bid, when it's resumed"
+          (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr2}))]
+            (is tx)))
+
+        (<! (web3-evm/increase-time @web3 (t/in-seconds (t/days 15))))
+
+        (testing "Emergency multisig can pause the registry"
+          (let [tx (<! (offering-registry/emergency-pause! {:from addr0}))]
+            (is tx)))
+
+        (testing "Finalizing is not possible on frozen registry"
+          (let [tx (<! (auction-offering/finalize! offering {:from addr1}))]
+            (is (nil? tx))))
+
+        (testing "Emergency multisig can release the registry"
+          (let [tx (<! (offering-registry/emergency-release! {:from addr0}))]
+            (is tx)))
+
+        (testing "Finalizing works when it's time"
+          (let [tx (<! (auction-offering/finalize! offering {:from addr1}))]
+            (is tx))))
+      (done))))
+
 
 (deftest freezed-buy-now-offering-behaviour
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
+                                                                               :offering/price (to-wei @web3 0.1 :ether)}
+                                                                              {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+        (testing "Registering name"
+          (is register-tx))
 
-    (testing "Making an instant offer"
-      (let [tx-hash (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
-                                                                :offering/price (eth->wei 0.1)}
-                                                               {:from addr1})]
-        (is tx-hash)
+        (testing "Making an instant offer"
+          (is create-offering-tx)
 
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr1})]
-          (testing "Transferring ownership to the offering"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr1})))
+        (testing "Transferring ownership to the offering"
+          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                             :ens.record/owner offering}
+                                            {:from addr1}))]
+            (is tx)))
 
-          (testing "Emergency multisig can pause the registry"
-            (is (offering-registry/emergency-pause! {:from addr0})))
+        (testing "Emergency multisig can pause the registry"
+          (let [tx (<! (offering-registry/emergency-pause! {:from addr0}))]
+            (is tx)))
 
-          (testing "Offering can't be bought while registry is frozen"
-            (is (thrown? :default (buy-now-offering/buy! {:offering/address offering}
-                                                         {:value (eth->wei 0.1)
-                                                          :from addr2}))))
+        (testing "Offering can't be bought while registry is frozen"
+          (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr2}))]
+            (is (nil? tx))))
 
-          (testing "Emergency multisig can release the registry"
-            (is (offering-registry/emergency-release! {:from addr0})))
+        (testing "Emergency multisig can release the registry"
+          (let [tx (<! (offering-registry/emergency-release! {:from addr0}))]
+            (is tx)))
 
-          (testing "Offering accepts the exact value"
-            (is (buy-now-offering/buy! {:offering/address offering}
-                                       {:value (eth->wei 0.1)
-                                        :from addr2}))))))))
+        (testing "Offering accepts the exact value"
+          (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                              {:value (to-wei @web3 0.1 :ether)
+                                               :from addr2}))]
+            (is tx)))))
+      (done))))

--- a/test/server/name_bazaar/smart_contract_tests.cljs
+++ b/test/server/name_bazaar/smart_contract_tests.cljs
@@ -1,17 +1,18 @@
 (ns server.name-bazaar.smart-contract-tests
   (:require
     [bignumber.core :as bn]
+    [cljs.core.async :refer [<! go]]
     [cljs-time.coerce :refer [to-epoch from-long]]
     [cljs-time.core :as time]
-    [cljs-web3.core :as web3]
-    [cljs-web3.eth :as web3-eth]
-    [cljs-web3.evm :as web3-evm]
-    [cljs.nodejs :as nodejs]
+    [cljs-web3-next.eth :as web3-eth]
+    [cljs-web3-next.evm :as web3-evm]
+    [cljs-web3-next.helpers :as web3-helpers]
+    [cljs-web3-next.utils :refer [to-wei]]
     [cljs.test :refer-macros [deftest is testing run-tests use-fixtures async]]
-    [district.server.smart-contracts :refer [contract-address]]
+    [clojure.string :as string]
+    [district.shared.async-helpers :refer [promise->]]
+    [district.server.smart-contracts :refer [contract-address instance]]
     [district.server.web3 :refer [web3]]
-    [district0x.shared.utils :as d0x-shared-utils :refer [eth->wei wei->eth]]
-    [mount.core :as mount]
     [name-bazaar.server.contracts-api.auction-offering :as auction-offering]
     [name-bazaar.server.contracts-api.auction-offering-factory :as auction-offering-factory]
     [name-bazaar.server.contracts-api.buy-now-offering :as buy-now-offering]
@@ -20,18 +21,16 @@
     [name-bazaar.server.contracts-api.offering :as offering]
     [name-bazaar.server.contracts-api.offering-registry :as offering-registry]
     [name-bazaar.server.contracts-api.registrar :as registrar]
-    [name-bazaar.server.contracts-api.used-by-factories :as used-by-factories]
     [name-bazaar.shared.smart-contracts]
-    [print.foo :include-macros true]))
-
-(def namehash (aget (js/require "eth-ens-namehash") "hash"))
-(def sha3 (comp (partial str "0x") (aget (js/require "js-sha3") "keccak_256")))
+    [print.foo :include-macros true]
+    [server.name-bazaar.utils :refer [after-test before-test get-balance namehash now sha3]]))
 
 ;; ganache-cli default value
 (def gas-price 2e10)
 
-(defn now []
-  (from-long (* (:timestamp (web3-eth/get-block @web3 (web3-eth/block-number @web3))) 1000)))
+(use-fixtures
+  :each {:before before-test
+         :after after-test})
 
 (defn get-transaction-cost
   "Get the total transaction cost for the given `transaction-address`.
@@ -39,44 +38,31 @@
   Returns a BigNumber of the total wei that was required to carry out
   the transaction."
   [transaction-address]
-  (let [transaction-receipt (web3-eth/get-transaction-receipt @web3 transaction-address)
-        unit-of-gas-used (:gas-used transaction-receipt)]
-    (bn/* unit-of-gas-used gas-price)))
-
-(use-fixtures
-  :each
-  {:before
-   (fn []
-     (-> (mount/with-args
-           {:web3 {:port 8549}
-            :smart-contracts {:contracts-var #'name-bazaar.shared.smart-contracts/smart-contracts
-                              :auto-mining? true}})
-         (mount/only [#'district.server.web3
-                      #'district.server.smart-contracts/smart-contracts])
-         (mount/start)))
-   :after
-   (fn []
-     (mount/stop)
-     (async done (js/setTimeout #(done) 500)))})
+  (promise-> (web3-eth/get-transaction-receipt @web3 transaction-address)
+             (fn [receipt]
+               (bn/* (:gas-used (web3-helpers/js->cljkk receipt)) gas-price))))
 
 
 (deftest contracts-setup
-  (is (= (contract-address :ens) (registrar/ens)))
-  (is (= (contract-address :ens) (auction-offering-factory/ens)))
-  (is (= (namehash "eth") (auction-offering-factory/root-node)))
-  (is (= (contract-address :offering-registry) (auction-offering-factory/offering-registry)))
+  (async done
+    (go
+      (is (= (contract-address :ens) (<! (registrar/ens))))
+      (is (= (contract-address :ens) (<! (auction-offering-factory/ens))))
+      (is (= (namehash "eth") (<! (auction-offering-factory/root-node))))
+      (is (= (contract-address :offering-registry) (<! (auction-offering-factory/offering-registry))))
 
-  (is (= (contract-address :ens) (buy-now-offering-factory/ens)))
-  (is (= (namehash "eth") (buy-now-offering-factory/root-node)))
-  (is (= (contract-address :offering-registry) (buy-now-offering-factory/offering-registry)))
+      (is (= (contract-address :ens) (<! (buy-now-offering-factory/ens))))
+      (is (= (namehash "eth") (<! (buy-now-offering-factory/root-node))))
+      (is (= (contract-address :offering-registry) (<! (buy-now-offering-factory/offering-registry))))
 
-  (is (= (first (web3-eth/accounts @web3)) (offering/emergency-multisig (contract-address :buy-now-offering))))
-  (is (= (contract-address :ens) (offering/ens (contract-address :buy-now-offering))))
-  (is (= (contract-address :offering-registry) (offering/offering-registry (contract-address :buy-now-offering))))
+      (is (= (first (<! (web3-eth/accounts @web3))) (<! (offering/emergency-multisig (contract-address :buy-now-offering)))))
+      (is (= (contract-address :ens) (<! (offering/ens (contract-address :buy-now-offering)))))
+      (is (= (contract-address :offering-registry) (<! (offering/offering-registry (contract-address :buy-now-offering)))))
 
-  (is (= (first (web3-eth/accounts @web3)) (offering/emergency-multisig (contract-address :auction-offering))))
-  (is (= (contract-address :ens) (offering/ens (contract-address :auction-offering))))
-  (is (= (contract-address :offering-registry) (offering/offering-registry (contract-address :auction-offering)))))
+      (is (= (first (<! (web3-eth/accounts @web3))) (<! (offering/emergency-multisig (contract-address :auction-offering)))))
+      (is (= (contract-address :ens) (<! (offering/ens (contract-address :auction-offering)))))
+      (is (= (contract-address :offering-registry) (<! (offering/offering-registry (contract-address :auction-offering)))))
+      (done))))
 
 
 (defn offering-status-keys [resp]
@@ -103,26 +89,31 @@
 
 
 (deftest create-buy-now-offering
-  (let [[addr0 addr1] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr0})))
+  (async done
+    (go
+      (let [[addr0 addr1] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"} {:from addr0}))]
+        (testing "Register name"
+          (is register-tx))
 
-    (testing "Making an instant offer"
-      (let [tx-hash (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
-                                                                :offering/price (eth->wei 0.1)}
-                                                               {:from addr0})]
-        (is tx-hash)
-        (let [{{:keys [:offering]} :args}
-              (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                  :from-block 0
-                                                                  :owner addr0})]
-          (testing "on-offering event should fire"
-            (is (not (nil? offering))))
-          (when offering
+        (testing "Ownership check"
+          (is (= addr0 (<! (registrar/registration-owner {:ens.record/label "abc"})))))
+
+        (testing "Making an instant offer"
+          (let [create-offering-tx (<! (buy-now-offering-factory/create-offering! {:offering/name "abc.eth"
+                                                                                   :offering/price (to-wei @web3 0.1 :ether)}
+                                                                                  {:from addr0}))
+                {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+
+            (testing "Create offering transaction successful"
+              (is create-offering-tx))
+
+            (testing "On-offering event should fire"
+              (is (not (nil? offering))))
+
             (testing "Offering parameters are correct"
               (is (= (offering-status-keys
-                       {:offering/address offering
+                       {:offering/address (string/lower-case offering)
                         :offering/type :buy-now-offering
                         :offering/top-level-name? true
                         :offering/name "abc.eth"
@@ -133,7 +124,7 @@
                         :offering/auction? false
                         :offering/contains-non-ascii? false
                         :offering/label-hash (sha3 "abc")
-                        :offering/original-owner addr0
+                        :offering/original-owner (string/lower-case addr0)
                         :offering/version 2
                         :offering/price 100000000000000000
                         :offering/label "abc"
@@ -142,380 +133,460 @@
                         :offering/new-owner nil
                         :offering/unregistered? false
                         :offering/supports-unregister? true})
-                     (offering-status-keys (offering/get-offering offering)))))
+                     (offering-status-keys (<! (offering/get-offering offering))))))
 
             (testing "Can't buy TLD if offering owns no registration"
-              (is (thrown? :default (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.1)
-                                                                                         :from addr1}))))
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.1 :ether)
+                                                   :from addr1}))]
+                (is (nil? tx))))
 
             (testing "Transferring ownership to the offering"
-              (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                       {:from addr0})))
+              (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                                 :ens.record/owner offering}
+                                                {:from addr0}))]
+                (is tx)))
 
             (testing "Making sure an offering isn't too greedy"
-              (is (thrown? :default
-                           (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.10001)
-                                                                                :from addr1}))))
-            (testing "Making sure an offering isn't too generous too"
-              (is (thrown? :default (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.09999)
-                                                                                         :from addr1}))))
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.10001 :ether)
+                                                   :from addr1}))]
+                (is (nil? tx))))
+
+            (testing "Making sure an offering isn't too generous either"
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.09999 :ether)
+                                                   :from addr1}))]
+                (is (nil? tx))))
+
             (testing "Offering accepts the exact value"
-              (is (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.1)
-                                                                       :from addr1})))
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.1 :ether)
+                                                  :from addr1}))]
+                (is tx)))
+
             (testing "Can't sell the offering twice"
-              (is (thrown? :default (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.1)
-                                                                                         :from addr1}))))
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.1 :ether)
+                                                   :from addr1}))]
+                (is (nil? tx))))
 
-            (testing "The name ownership must be transferred to the new owner"
-              (is (= addr1 (ens/owner {:ens.record/node (namehash "abc.eth")}))))
-            (testing "Ensuring the new owner gets his registration"
-              (is (= addr1 (registrar/registration-owner {:ens.record/label "abc"}))))
+            (testing "ENS ownership must be transferred to the new owner"
+              (is (= addr1 (<! (ens/owner {:ens.record/node (namehash "abc.eth")})))))
+
+            (testing ".eth registrar ownership must be transferred to the new owner"
+              (is (= addr1 (<! (registrar/registration-owner {:ens.record/label "abc"})))))
+
             (testing "New-owner of the offering is set"
-              (is (= addr1 (:offering/new-owner (offering/get-offering offering)))))))))))
+              (is (= (string/lower-case addr1) (:offering/new-owner (<! (offering/get-offering offering)))))))))
+        (done))))
 
 
+;; TODO this test can't have more assertions or it crashes
+;; https://ask.clojure.org/index.php/10546/analyzer-error-when-there-are-more-than-21-tests-in-cljs-test
 (deftest create-auction-offering
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr0})))
-    (testing "Offering the name with overdue endtime fails"
-      (is (thrown? :default (auction-offering-factory/create-offering!
-                              {:offering/name "abc.eth"
-                               :offering/price (eth->wei 0.1)
-                               :auction-offering/end-time (to-epoch (time/minus (now) (time/seconds 1)))
-                               :auction-offering/extension-duration 0
-                               :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                              {:from addr0}))))
-    (testing "Offering the name with 0 bidincrease fails"
-      (is (thrown? :default (auction-offering-factory/create-offering!
-                              {:offering/name "abc.eth"
-                               :offering/price (eth->wei 0.1)
-                               :auction-offering/end-time (to-epoch (time/plus (now) (time/weeks 1)))
-                               :auction-offering/extension-duration 0
-                               :auction-offering/min-bid-increase (web3/to-wei 0 :ether)}
-                              {:from addr0}))))
-    (let [tx-hash (auction-offering-factory/create-offering!
-                    {:offering/name "abc.eth"
-                     :offering/price (eth->wei 0.1)
-                     :auction-offering/end-time (to-epoch (time/plus (now) (time/weeks 2)))
-                     :auction-offering/extension-duration 0
-                     :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                    {:from addr0})]
-      (testing "Offering the name for a bid"
-        (is tx-hash))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"} {:from addr0}))]
 
-      (let [{{:keys [:offering]} :args}
-            (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                :from-block 0
-                                                                :owner addr0})
-            bid-value-user-2 (web3/to-wei 0.2 :ether)]
-        (testing "on-offering event should fire"
-          (is (not (nil? offering))))
-        (when offering
+        (testing "Offering the name with overdue endtime fails"
+          (let [tx (<! (auction-offering-factory/create-offering!
+                         {:offering/name "abc.eth"
+                          :offering/price (to-wei @web3 0.1 :ether)
+                          :auction-offering/end-time (to-epoch (time/minus (<! (now)) (time/seconds 1)))
+                          :auction-offering/extension-duration 0
+                          :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                         {:from addr0}))]
+            (is (nil? tx))))
+
+        (testing "Offering the name with 0 bidincrease fails"
+          (let [tx (<! (auction-offering-factory/create-offering!
+                         {:offering/name "abc.eth"
+                          :offering/price (to-wei @web3 0.1 :ether)
+                          :auction-offering/end-time (to-epoch (time/plus (<! (now)) (time/weeks 1)))
+                          :auction-offering/extension-duration 0
+                          :auction-offering/min-bid-increase (to-wei @web3 0 :ether)}
+                         {:from addr0}))]
+            (is (nil? tx))))
+
+        (let [create-offering-tx (<! (auction-offering-factory/create-offering!
+                                       {:offering/name "abc.eth"
+                                        :offering/price (to-wei @web3 0.1 :ether)
+                                        :auction-offering/end-time (to-epoch (time/plus (<! (now)) (time/weeks 2)))
+                                        :auction-offering/extension-duration 0
+                                        :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                       {:from addr0}))
+              {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))
+              bid-value-user-2 (to-wei @web3 0.2 :ether)]
+
+          (testing "Offering the name for a bid"
+            (is create-offering-tx))
+
+          (testing "On-offering event should fire"
+            (is (not (nil? offering))))
 
           (testing "Transferring ownership to the offer"
-            (is (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                     {:from addr0})))
+            (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
+                                               :ens.record/owner offering}
+                                              {:from addr0}))]
+              (is tx)))
+
           (testing "Can't bid below the price"
-            (is (thrown? :default (auction-offering/bid! {:offering/address offering}
-                                                         {:value (web3/to-wei 0.09 :ether)
-                                                          :from addr1}))))
+            (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                {:value (to-wei @web3 0.09 :ether)
+                                                 :from addr1}))]
+              (is (nil? tx))))
+
           (testing "Can place a proper bid"
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value (web3/to-wei 0.1 :ether)
-                                        :from addr1})))
+            (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                {:value (to-wei @web3 0.1 :ether)
+                                                 :from addr1}))]
+              (is tx)))
+
           (testing "Next bid should respect min-bid-increase"
-            (is (thrown? :default (auction-offering/bid! {:offering/address offering}
-                                                         {:value (web3/to-wei 0.11 :ether)
-                                                          :from addr2}))))
+            (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                {:value (to-wei @web3 0.11 :ether)
+                                                 :from addr1}))]
+              (is (nil? tx))))
+
           (testing "Correct increase of the bid is accepted"
-            (is (auction-offering/bid! {:offering/address offering}
-                                       {:value bid-value-user-2
-                                        :from addr2})))
-          (let [balance-of-2 (web3-eth/get-balance @web3 addr2)]
+            (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                {:value bid-value-user-2
+                                                 :from addr2}))]
+              (is tx)))
+
+          (let [balance-of-2 (<! (get-balance addr2))]
             (testing "Arbitrary increase of the bid is ok"
-              (is (auction-offering/bid! {:offering/address offering}
-                                         {:value (web3/to-wei 0.33 :ether)
-                                          :from addr3})))
+              (let [tx (<! (auction-offering/bid! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.33 :ether)
+                                                   :from  addr3}))]
+                (is tx)))
 
             (testing "State of the auction offering is correct"
               (is (= {:auction-offering/min-bid-increase 100000000000000000
-                      :auction-offering/winning-bidder addr3
-                      :auction-offering/bid-count 3}
-                     (select-keys (auction-offering/get-auction-offering offering)
+                      :auction-offering/winning-bidder   (string/lower-case addr3)
+                      :auction-offering/bid-count        3}
+                     (select-keys (<! (auction-offering/get-auction-offering offering))
                                   [:auction-offering/min-bid-increase
                                    :auction-offering/winning-bidder
                                    :auction-offering/bid-count]))))
 
             (testing "Can't finalize the auction prematurely"
-              (is (thrown? :default (auction-offering/finalize! offering {:from addr0}))))
+              (let [tx (<! (auction-offering/finalize! offering {:from addr0}))]
+                (is (nil? tx))))
 
-            (web3-evm/increase-time! @web3 [(time/in-seconds (time/days 15))])
+            (<! (web3-evm/increase-time @web3 (time/in-seconds (time/days 15))))
 
             (testing "User who was overbid, can successfully withdraw funds from auction offering."
-              (is (auction-offering/withdraw! {:address addr1
-                                               :offering offering}
-                                              {:from addr1})))
-            (testing "Finalizing works when it's time"
-              (is (auction-offering/finalize! offering {:from addr0})))
-            (testing "Ensuring the new owner gets his name"
-              (is (= addr3 (ens/owner {:ens.record/node (namehash "abc.eth")}))))
-            (testing "Ensuring the new owner gets his registration"
-              (is (= addr3 (registrar/registration-owner {:ens.record/label "abc"}))))
+              (let [tx (<! (auction-offering/withdraw! {:address addr1
+                                                        :offering offering}
+                                                       {:from addr2}))]
+                (is tx)))
 
-            (testing "User who was overbid, getting his funds back from auction offering."
-              ;; Note: transaction costs don't apply, `balance-of-2` is tracked after the bid
-              (let [expected-balance (bn/+ balance-of-2 bid-value-user-2)
-                    actual-balance (web3-eth/get-balance @web3 addr2)]
-                (is (bn/zero? (bn/- expected-balance actual-balance)))))))))))
+            (testing "Finalizing works when it's time"
+              (let [tx (<! (auction-offering/finalize! offering {:from addr0}))]
+                (is tx)))
+
+            (testing "Ensuring the new owner gets his name"
+              (is (= addr3 (<! (ens/owner {:ens.record/node (namehash "abc.eth")})))))
+
+            (testing "Ensuring the new owner gets his registration"
+              (is (= addr3 (<! (registrar/registration-owner {:ens.record/label "abc"})))))
+
+            (let [expected-balance (bn/+ balance-of-2 (bn/number bid-value-user-2))
+                  actual-balance (<! (get-balance addr2))]
+              (testing "User who was overbid, getting his funds back from auction offering."
+                ;; Note: transaction costs don't apply, `balance-of-2` is tracked after the bid
+                (is (bn/zero? (bn/- expected-balance actual-balance))))))))
+      (done))))
 
 
 (deftest offering-tld-ownership
-  (let [[addr0 addr1] (web3-eth/accounts @web3)]
-    (testing "Register tld, then transfer registration ownership, but retain registry ownership"
-      (is (registrar/register! {:ens.record/label "tld"}
-                               {:from addr0}))
-      (is (= addr0 (registrar/registration-owner {:ens.record/label "tld"})))
-      (is (registrar/transfer! {:ens.record/label "tld"
-                                :ens.record/owner addr1}
-                               {:from addr0}))
-      (is (= addr1 (registrar/registration-owner {:ens.record/label "tld"})))
-      (is (= addr0 (ens/owner {:ens.record/name "tld.eth"}))))
+  (async done
+    (go
+      (let [[addr0 addr1] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "tld"}
+                                                 {:from addr0}))]
 
-    (testing "Can't make an instant offer on not owned domain"
-      (is (thrown? :default (buy-now-offering-factory/create-offering! {:offering/name "tld"
-                                                                        :offering/price (eth->wei 0.1)}
-                                                                       {:from addr1}))))
-    (testing "Can't make an instant offer on domain we own in registry, but not in registrar"
-      (is (thrown? :default (buy-now-offering-factory/create-offering! {:offering/name "tld"
-                                                                        :offering/price (eth->wei 0.1)}
-                                                                       {:from addr0}))))
+        (testing "Register tld, then transfer registration ownership, but retain registry ownership"
+          (is register-tx)
+          (is (= addr0 (<! (registrar/registration-owner {:ens.record/label "tld"}))))
+          (let [tx (<! (registrar/transfer! {:ens.record/label "tld"
+                                             :ens.record/owner addr1}
+                                            {:from addr0}))]
+            (is tx))
+          (is (= addr1 (<! (registrar/registration-owner {:ens.record/label "tld"}))))
+          (is (= addr0 (<! (ens/owner {:ens.record/name "tld.eth"})))))
 
-    (testing "Can't make auction offer on not owned domain"
-      (is (thrown? :default (auction-offering-factory/create-offering!
-                              {:offering/name "tld"
-                               :offering/price (eth->wei 0.1)
-                               :auction-offering/end-time (to-epoch (time/plus (now) (time/weeks 2)))
-                               :auction-offering/extension-duration 0
-                               :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                              {:from addr1}))))
-    (testing "Can't make auction offer on domain we own in registry, but not in registrar"
-      (is (thrown? :default (auction-offering-factory/create-offering!
-                              {:offering/name "tld"
-                               :offering/price (eth->wei 0.1)
-                               :auction-offering/end-time (to-epoch (time/plus (now) (time/weeks 2)))
-                               :auction-offering/extension-duration 0
-                               :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                              {:from addr0}))))))
+        (testing "Can't make an instant offer on not owned domain"
+          (let [tx (<! (buy-now-offering-factory/create-offering! {:offering/name "tld"
+                                                                   :offering/price (to-wei @web3 0.1 :ether)}
+                                                                  {:from addr1}))]
+            (is (nil? tx))))
+
+        (testing "Can't make an instant offer on domain we own in registry, but not in registrar"
+          (let [tx (<! (buy-now-offering-factory/create-offering! {:offering/name "tld"
+                                                                   :offering/price (to-wei @web3 0.1 :ether)}
+                                                                  {:from addr0}))]
+            (is (nil? tx))))
+
+        (testing "Can't make auction offer on not owned domain"
+          (let [tx (<! (auction-offering-factory/create-offering!
+                         {:offering/name "tld"
+                          :offering/price (to-wei @web3 0.1 :ether)
+                          :auction-offering/end-time (to-epoch (time/plus (<! (now)) (time/weeks 2)))
+                          :auction-offering/extension-duration 0
+                          :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                         {:from addr1}))]
+            (is (nil? tx))))
+
+        (testing "Can't make auction offer on domain we own in registry, but not in registrar"
+          (let [tx (<! (auction-offering-factory/create-offering!
+                         {:offering/name "tld"
+                          :offering/price (to-wei @web3 0.1 :ether)
+                          :auction-offering/end-time (to-epoch (time/plus (<! (now)) (time/weeks 2)))
+                          :auction-offering/extension-duration 0
+                          :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                         {:from addr0}))]
+            (is (nil? tx)))))
+      (done))))
+
 
 (deftest offering-subdomain-ownership
-  (let [[addr0 addr1 addr2] (web3-eth/accounts @web3)]
-    (testing "Registering name to add subdomain"
-      (is (registrar/register! {:ens.record/label "tld"}
-                               {:from addr0}))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "tld"}
+                                                 {:from addr0}))
+            set-subnode-owner-tx-1 (<! (ens/set-subnode-owner!
+                                         {:ens.record/label "mysub"
+                                          :ens.record/node "tld.eth"
+                                          :ens.record/owner addr0}
+                                         {:from addr0}))
+            set-subnode-owner-tx-2 (<! (ens/set-subnode-owner!
+                                         {:ens.record/label "theirsub"
+                                          :ens.record/node "tld.eth"
+                                          :ens.record/owner addr1}
+                                         {:from addr0}))]
 
-      (is (ens/set-subnode-owner!
-            {:ens.record/label "mysub"
-             :ens.record/node "tld.eth"
-             :ens.record/owner addr0}
-            {:from addr0}))
+        (testing "Registering name to add subdomain"
+          (is register-tx)
+          (is (= addr0 (<! (ens/owner {:ens.record/node (namehash "tld.eth")}))))
+          (is set-subnode-owner-tx-1)
+          (is (= addr0 (<! (ens/owner {:ens.record/node (namehash "mysub.tld.eth")}))))
+          (is set-subnode-owner-tx-2)
+          (is (= addr1 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))
 
-      (is (= addr0 (ens/owner {:ens.record/node (namehash "mysub.tld.eth")})))
-      (is (ens/set-subnode-owner!
-            {:ens.record/label "theirsub"
-             :ens.record/node "tld.eth"
-             :ens.record/owner addr1}
-            {:from addr0}))
-      (is (= addr0 (ens/owner {:ens.record/node (namehash "tld.eth")})))
-      (is (= addr1 (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))
+        (testing "Can't make an instant offer if we own parent domain, but not domain itself"
+          (let [tx (<! (buy-now-offering-factory/create-offering! {:offering/name "theirsub.tld.eth"
+                                                                   :offering/price (to-wei @web3 0.1 :ether)}
+                                                                  {:from addr0}))]
+            (is (nil? tx))))
 
-    (testing "Can't make an instant offer if we own parent domain, but not domain itself"
-      (is (thrown? :default (buy-now-offering-factory/create-offering! {:offering/name "theirsub.tld.eth"
-                                                                        :offering/price (eth->wei 0.1)}
-                                                                       {:from addr0}))))
-    (let [tx-hash (buy-now-offering-factory/create-offering! {:offering/name "theirsub.tld.eth"
-                                                              :offering/price (eth->wei 0.1)}
+        (testing "Making an instant offer as an administrator"
+          (let [create-offering-tx (<! (buy-now-offering-factory/create-offering!
+                                         {:offering/name "theirsub.tld.eth"
+                                          :offering/price (to-wei @web3 0.1 :ether)}
+                                         {:from addr1}))
+                {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
+            (is create-offering-tx)
 
-                                                             {:from addr1})]
-      (testing "Making an instant offer as an administrator"
-        (is tx-hash))
+            (testing "Can't buy it yet, as subdomain ownership not transferred"
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.1 :ether)
+                                                   :from addr2}))]
+                (is (nil? tx))))
 
-      (let [{{:keys [:offering]} :args}
-            (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "theirsub.tld.eth")
-                                                                :from-block 0
-                                                                :owner addr1})]
-        (testing "Can't buy it yet, as subdomain ownership not transferred"
-          (is (thrown? :default (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.1)
-                                                                                     :from addr2}))))
-        (testing "Transferring ownership to the offering"
-          (is (ens/set-owner! {:ens.record/node (namehash "theirsub.tld.eth")
-                               :ens.record/owner offering}
-                              {:from addr1})))
+            (testing "Transferring ownership to the offering"
+              (let [tx (<! (ens/set-owner! {:ens.record/name "theirsub.tld.eth"
+                                            :ens.record/owner offering}
+                                           {:from addr1}))]
+                (is tx)))
 
-        (testing "Now it can be sold"
-          (is (buy-now-offering/buy! {:offering/address offering} {:value (eth->wei 0.1)
-                                                                   :from addr2})))
+            (testing "Now it can be sold"
+              (let [tx (<! (buy-now-offering/buy! {:offering/address offering}
+                                                  {:value (to-wei @web3 0.1 :ether)
+                                                   :from addr2}))]
+                (is tx)))
 
-        (testing "The new owner changes"
-          (is (= addr2 (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")})))))
+            (testing "The new owner changes"
+              (is (= addr2 (<! (ens/owner {:ens.record/node (namehash "theirsub.tld.eth")}))))))
 
-      (testing "Making an instant offer if not an owner fails"
-        (is (thrown? :default (buy-now-offering-factory/create-offering! {:offering/name "mysub.tld.eth"
-                                                                          :offering/price (eth->wei 0.1)}
-                                                                         {:from addr1}))))
+          (testing "Making an instant offer if not an owner fails"
+            (let [tx (<! (buy-now-offering-factory/create-offering! {:offering/name "mysub.tld.eth"
+                                                                     :offering/price (to-wei @web3 0.1 :ether)}
+                                                                    {:from addr1}))]
+              (is (nil? tx))))
 
-      (testing "Making an instant offer as a owner"
-        (is (buy-now-offering-factory/create-offering! {:offering/name "mysub.tld.eth"
-                                                        :offering/price (eth->wei 0.1)}
-                                                       {:from addr0}))))))
+          (testing "Making an instant offer as a owner"
+            (let [tx (<! (buy-now-offering-factory/create-offering! {:offering/name "mysub.tld.eth"
+                                                                     :offering/price (to-wei @web3 0.1 :ether)}
+                                                                    {:from addr0}))]
+              (is tx)))))
+      (done))))
+
 
 (deftest auction-offering-self-overbid
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr1})))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))
+            register-tx (<! (registrar/register! {:ens.record/label "abc"}
+                                                 {:from addr1}))
+            create-offering-tx (<! (auction-offering-factory/create-offering!
+                                     {:offering/name "abc.eth"
+                                      :offering/price (to-wei @web3 0.1 :ether)
+                                      :auction-offering/end-time (to-epoch (time/plus (<! (now)) (time/weeks 2)))
+                                      :auction-offering/extension-duration 0
+                                      :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                                     {:from addr1}))
+            {offering :offering} (<! (offering-registry/on-offering-added-in-tx create-offering-tx))]
 
-    (let [tx-hash (auction-offering-factory/create-offering!
-                    {:offering/name "abc.eth"
-                     :offering/price (eth->wei 0.1)
-                     :auction-offering/end-time (to-epoch (time/plus (now) (time/weeks 2)))
-                     :auction-offering/extension-duration 0
-                     :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                    {:from addr1})]
+        (testing "Registering name"
+          (is register-tx))
 
-      (testing "Offering the name for a bid"
-        (is tx-hash))
+        (testing "Offering the name for a bid"
+          (is create-offering-tx))
 
-      (let [{{:keys [:offering]} :args}
-            (offering-registry/on-offering-added-in-tx tx-hash {:node (namehash "abc.eth")
-                                                                :from-block 0
-                                                                :owner addr1})]
-        (testing "on-offering event should fire"
+        (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
         (let [;; starting account balances
-              balance-of-1 (web3-eth/get-balance @web3 addr1)
-              balance-of-2 (web3-eth/get-balance @web3 addr2)
-              balance-of-3 (web3-eth/get-balance @web3 addr3)
+              balance-of-1 (<! (get-balance addr1))
+              balance-of-2 (<! (get-balance addr2))
+              balance-of-3 (<! (get-balance addr3))
 
               ;; bid values
-              bid-value-user-2 (web3/to-wei 0.1 :ether)
-              bid-value-user-3 (web3/to-wei 0.2 :ether)
-              bid-value-user-3-overbid (web3/to-wei 0.3 :ether)
+              bid-value-user-2 (to-wei @web3 0.1 :ether)
+              bid-value-user-3 (to-wei @web3 0.2 :ether)
+              bid-value-user-3-overbid (to-wei @web3 0.3 :ether)
 
               ;; A temporary transaction log store
               transaction-log (atom {})
-              log-tx! (fn [id result] (swap! transaction-log assoc id result) result)]
+              log-tx! (fn [id {:keys [:transaction-hash]}]
+                        (swap! transaction-log assoc id transaction-hash) transaction-hash)]
 
           (testing "Transferring ownership to the offer"
             (is (log-tx! :t1-transfer
-                         (registrar/transfer! {:ens.record/label "abc" :ens.record/owner offering}
-                                              {:from addr1}))))
+                         (<! (registrar/transfer! {:ens.record/label "abc"
+                                                   :ens.record/owner offering}
+                                                  {:from addr1})))))
 
           (testing "User 2 can place a proper bid"
             (is (log-tx! :t2-user2-place-bid
-                         (auction-offering/bid! {:offering/address offering}
-                                                {:value bid-value-user-2
-                                                 :from addr2}))))
+                         (<! (auction-offering/bid! {:offering/address offering}
+                                                    {:value bid-value-user-2
+                                                     :from addr2})))))
 
           (testing "Ensure User 2 has made the appropriate bid transaction with gas costs."
             (let [bid-tx (:t2-user2-place-bid @transaction-log)
-                  tx-total-cost (get-transaction-cost bid-tx)
+                  tx-total-cost (<! (get-transaction-cost bid-tx))
                   expected-balance (bn/- balance-of-2 tx-total-cost)
                   expected-balance (bn/- expected-balance bid-value-user-2)
-                  actual-balance (web3-eth/get-balance @web3 addr2)]
+                  actual-balance (<! (get-balance addr2))]
               (is (bn/zero? (bn/- expected-balance actual-balance)))))
 
           (testing "User 3 can place a proper bid too"
             (is (log-tx! :t3-user3-place-bid
-                         (auction-offering/bid! {:offering/address offering}
-                                                {:value bid-value-user-3
-                                                 :from addr3}))))
+                         (<! (auction-offering/bid! {:offering/address offering}
+                                                    {:value bid-value-user-3
+                                                     :from addr3})))))
 
           ;; FIXME: Compare to transaction receipt for original gas spent
           ;; Issue # 131
           (testing "User 2, who was overbid, should have his funds back from auction offering."
             (let [;; The user will have his funds back, but he would still have paid a gas price
                   bid-tx (:t2-user2-place-bid @transaction-log)
-                  tx-total-cost (get-transaction-cost bid-tx)
+                  tx-total-cost (<! (get-transaction-cost bid-tx))
                   expected-balance (bn/- balance-of-2 tx-total-cost)
-                  actual-balance (web3-eth/get-balance @web3 addr2)]
+                  actual-balance(<! (get-balance addr2))]
               (is (bn/zero? (bn/- expected-balance actual-balance)))))
 
           (testing "User 3 funds are spent on the bid"
             (let [bid-tx (:t3-user3-place-bid @transaction-log)
-                  tx-total-cost (get-transaction-cost bid-tx)
+                  tx-total-cost (<! (get-transaction-cost bid-tx))
                   expected-balance (bn/- balance-of-3 tx-total-cost)
                   expected-balance (bn/- expected-balance bid-value-user-3)
-                  actual-balance (web3-eth/get-balance @web3 addr3)]
+                  actual-balance (<! (get-balance addr3))]
               (is (bn/zero? (bn/- expected-balance actual-balance)))))
 
           (testing "User 3 can overbid in order to afk himself"
             (is (log-tx! :t4-user3-place-overbid
-                         (auction-offering/bid! {:offering/address offering}
-                                                {:value bid-value-user-3-overbid
-                                                 :from addr3}))))
+                         (<! (auction-offering/bid! {:offering/address offering}
+                                                    {:value bid-value-user-3-overbid
+                                                     :from addr3})))))
 
           ;; FIXME: Compare to transaction receipt for original gas spent
           ;; Issue # 131
           (testing "User 3 who overbid himself, gets back only his own previous bids."
             (let [bid-tx-3 (:t3-user3-place-bid @transaction-log)
                   bid-tx-4 (:t4-user3-place-overbid @transaction-log)
-                  tx-total-cost (bn/+ (get-transaction-cost bid-tx-3)
-                                      (get-transaction-cost bid-tx-4))
+                  tx-total-cost (bn/+ (<! (get-transaction-cost bid-tx-3))
+                                      (<! (get-transaction-cost bid-tx-4)))
                   expected-balance (bn/- balance-of-3 tx-total-cost)
-                  expected-balance (bn/- expected-balance bid-value-user-3-overbid)
-                  actual-balance (web3-eth/get-balance @web3 addr3)]
+                  expected-balance (bn/- expected-balance (bn/number bid-value-user-3-overbid))
+                  actual-balance (<! (get-balance addr3))]
               (is (bn/zero? (bn/- expected-balance actual-balance)))))
 
-          (web3-evm/increase-time! @web3 [(time/in-seconds (time/days 15))])
+          (<! (web3-evm/increase-time @web3 (time/in-seconds (time/days 15))))
 
           (testing "State of the auction offering is correct"
             (is (= {:auction-offering/min-bid-increase 100000000000000000
-                    :auction-offering/winning-bidder addr3
+                    :auction-offering/winning-bidder (string/lower-case addr3)
                     :auction-offering/bid-count 3}
-                   (select-keys (auction-offering/get-auction-offering offering)
+                   (select-keys (<! (auction-offering/get-auction-offering offering))
                                 [:auction-offering/min-bid-increase
                                  :auction-offering/winning-bidder
                                  :auction-offering/bid-count]))))
 
           (testing "Finalizing works when it's time"
             (is (log-tx! :t5-user1-finalize
-                         (auction-offering/finalize! offering {:from addr0}))))
+                         (<! (auction-offering/finalize! offering {:from addr0})))))
+
           (testing "Ensuring the new owner gets his name"
-            (is (= addr3 (ens/owner {:ens.record/node (namehash "abc.eth")}))))
+            (is (= addr3 (<! (ens/owner {:ens.record/node (namehash "abc.eth")})))))
+
           (testing "Ensuring the new owner gets his registration"
-            (is (= addr3 (registrar/registration-owner {:ens.record/label "abc"}))))
+            (is (= addr3 (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
           (testing "Ensuring the previous owner gets the funds"
             (let [bid-tx-1 (:t1-transfer @transaction-log)
-                  tx-total-cost (get-transaction-cost bid-tx-1)
-                  expected-balance (bn/+ balance-of-1 bid-value-user-3-overbid)
+                  tx-total-cost (<! (get-transaction-cost bid-tx-1))
+                  expected-balance (bn/+ balance-of-1 (bn/number bid-value-user-3-overbid))
                   expected-balance (bn/- expected-balance tx-total-cost)
-                  actual-balance (web3-eth/get-balance @web3 addr1)]
-              (is (bn/zero? (bn/- expected-balance actual-balance))))))))))
+                  actual-balance (<! (get-balance addr1))]
+              (is (bn/zero? (bn/- expected-balance actual-balance)))))))
+      (done))))
+
 
 (deftest create-auction-offering-sanity-checks
-  (let [[addr0 addr1 addr2 addr3] (web3-eth/accounts @web3)]
-    (testing "Registering name"
-      (is (registrar/register! {:ens.record/label "abc"}
-                               {:from addr0})))
-    (testing "Offering with the endtime too far in the future fails"
-      (is (thrown? :default (auction-offering-factory/create-offering!
-                              {:offering/name "abc.eth"
-                               :offering/price (eth->wei 0.1)
-                               :auction-offering/end-time (to-epoch (time/plus (now)
-                                                                               (time/days (* 4 30))
-                                                                               (time/hours 1)))
-                               :auction-offering/extension-duration 0
-                               :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                              {:from addr0}))))
-    (testing "Offering with the extension duration longer than auction duration fails"
-      (is (thrown? :default (auction-offering-factory/create-offering!
-                              {:offering/name "abc.eth"
-                               :offering/price (eth->wei 0.1)
-                               :auction-offering/end-time (to-epoch (time/plus (now) (time/days (* 2 30))))
-                               :auction-offering/extension-duration (time/in-seconds (time/days 61))
-                               :auction-offering/min-bid-increase (web3/to-wei 0.1 :ether)}
-                              {:from addr0}))))))
+  (async done
+    (go
+      (let [[addr0 addr1 addr2 addr3] (<! (web3-eth/accounts @web3))]
+        (testing "Registering name"
+          (let [tx (<! (registrar/register! {:ens.record/label "abc"}
+                                            {:from addr0}))]
+            (is tx)))
+
+        (testing "Offering with the endtime too far in the future fails"
+          (let [tx (<! (auction-offering-factory/create-offering!
+                         {:offering/name "abc.eth"
+                          :offering/price (to-wei @web3 0.1 :ether)
+                          :auction-offering/end-time (to-epoch (time/plus (<! (now))
+                                                                          (time/days (* 4 30))
+                                                                          (time/hours 1)))
+                          :auction-offering/extension-duration 0
+                          :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                         {:from addr0}))]
+            (is (nil? tx))))
+
+        (testing "Offering with the extension duration longer than auction duration fails"
+          (let [tx (<! (auction-offering-factory/create-offering!
+                         {:offering/name "abc.eth"
+                          :offering/price (to-wei @web3 0.1 :ether)
+                          :auction-offering/end-time (to-epoch (time/plus (<! (now)) (time/days (* 2 30))))
+                          :auction-offering/extension-duration (time/in-seconds (time/days 61))
+                          :auction-offering/min-bid-increase (to-wei @web3 0.1 :ether)}
+                         {:from addr0}))]
+            (is (nil? tx)))))
+      (done))))

--- a/test/server/name_bazaar/utils.cljs
+++ b/test/server/name_bazaar/utils.cljs
@@ -1,5 +1,6 @@
 (ns server.name-bazaar.utils
   (:require
+    [bignumber.core :as bn]
     [cljs.core.async :refer [<! go]]
     [cljs.test :refer-macros [async]]
     [cljs-time.coerce :refer [from-long]]
@@ -23,6 +24,11 @@
              (fn [block]
                (let [block (web3-helpers/js->cljkk block)]
                  (from-long (* (:timestamp block) 1000))))))
+
+
+(defn get-balance [address]
+  (promise-> (web3-eth/get-balance @web3 address)
+             bn/number))
 
 
 (defn before-test []

--- a/test/server/name_bazaar/utils.cljs
+++ b/test/server/name_bazaar/utils.cljs
@@ -1,0 +1,64 @@
+(ns server.name-bazaar.utils
+  (:require
+    [cljs.core.async :refer [<! go]]
+    [cljs.test :refer-macros [async]]
+    [cljs-time.coerce :refer [from-long]]
+    [cljs-web3-next.eth :as web3-eth]
+    [cljs-web3-next.evm :as web3-evm]
+    [cljs-web3-next.helpers :as web3-helpers]
+    [district.server.web3 :refer [web3]]
+    [district.shared.async-helpers :refer [promise->]]
+    [mount.core :as mount]
+    [taoensso.timbre :as log]))
+
+(def snapshot-id (atom ""))
+
+(def namehash (aget (js/require "eth-ens-namehash") "hash"))
+(def sha3 (comp (partial str "0x") (aget (js/require "js-sha3") "keccak_256")))
+
+
+(defn now []
+  (promise-> (web3-eth/get-block-number @web3)
+             #(web3-eth/get-block @web3 % false)
+             (fn [block]
+               (let [block (web3-helpers/js->cljkk block)]
+                 (from-long (* (:timestamp block) 1000))))))
+
+
+(defn before-test []
+  (async done
+    (go
+      (-> (mount/with-args
+            {:web3            {:url        "ws://127.0.0.1:8549"
+                               :on-online  #(log/warn "Ethereum node went online")
+                               :on-offline #(log/warn "Ethereum node went offline")}
+             :smart-contracts {:contracts-build-path "./resources/public/contracts-build/"
+                               :contracts-var        #'name-bazaar.shared.smart-contracts/smart-contracts
+                               :auto-mining?         true}})
+          (mount/only [#'district.server.web3
+                       #'district.server.smart-contracts/smart-contracts])
+          (mount/start))
+      (let [id (<! (web3-evm/snapshot @web3))]
+        (swap! snapshot-id (fn [_] id)))
+      (done))))
+
+
+(defn after-test []
+  (async done
+    (go
+      ;; we'd like to use cljs-web3-next.evm/revert here, but it's broken now as:
+      ;; 1. evm_revert doesn't accept 0 arguments even if it should:
+      ;;    https://github.com/trufflesuite/ganache-cli/issues/672
+      ;; 2. evm_revert is a non-standard method not explicitly supported in web3js
+      ;; 3. there's a validator expecting by default any non-standard method to have 0 args
+      ;; so we need to go more low level
+      (js-invoke (aget @web3 "currentProvider")
+                 "send"
+                 (clj->js {:jsonrpc "2.0",
+                           :method "evm_revert",
+                           :params [@snapshot-id],
+                           :id 1})
+                 (fn [err _]
+                   (if err (throw (js/Error. "Error evm_revert-ing to snapshot" err)))
+                   (mount/stop)
+                   (js/setTimeout #(done) 500))))))

--- a/test/server/run_tests.cljs
+++ b/test/server/run_tests.cljs
@@ -12,6 +12,6 @@
 
 (set! (.-error js/console) (fn [x] (.log js/console x)))
 
-(doo-tests #_'server.name-bazaar.smart-contract-tests
-           #_'server.name-bazaar.smart-contract-ext-tests
-           #_'server.name-bazaar.smart-contract-altering-tests)
+(doo-tests 'server.name-bazaar.smart-contract-tests
+           'server.name-bazaar.smart-contract-ext-tests
+           'server.name-bazaar.smart-contract-altering-tests)


### PR DESCRIPTION
We update server tests that were left behind when updating serverside web3.

Notable changes:
* we use snapshots functionality available on providers like ganache and hardhat to clean chain state between tests - faster than contracts redeploy
* update everything to work with returned promises
* test macros can have unexpected interplays with `go, <!`: https://ask.clojure.org/index.php/10546/analyzer-error-when-there-are-more-than-21-tests-in-cljs-test

