### PR TITLE
Fix dev deploy of reverse registrar

### DIFF
--- a/resources/public/contracts-migration/2_namebazaar_migration.js
+++ b/resources/public/contracts-migration/2_namebazaar_migration.js
@@ -146,12 +146,14 @@ module.exports = async function (deployer, network, accounts) {
       deploy(NamebazaarDevNameResolver)
     )
 
-    const [nameBazaarDevRegistrar] = await parallel(
+    const [nameBazaarDevRegistrar, _, namebazaarDevReverseRegistrar] = await parallel(
       deploy(NameBazaarDevRegistrar, ens.address, namehash('eth')),
       deploy(NamebazaarDevPublicResolver, ens.address),
       deploy(NamebazaarDevReverseRegistrar, ens.address, namebazaarDevNameResolver.address)
     )
     await ens.setSubnodeOwner(namehash(''), ensLabel('eth'), nameBazaarDevRegistrar.address)
+    await ens.setSubnodeOwner(namehash(''), ensLabel('reverse'), accounts[0]);
+    await ens.setSubnodeOwner(namehash('reverse'), ensLabel('addr'), namebazaarDevReverseRegistrar.address);
   } else {
     const config = deployer.networks[network].deploymentConfig
     validateDeploymentConfig(config)


### PR DESCRIPTION
resolves #180 

In dev deployment of smart contracts, we weren't setting ENS owner of `reverse` and `reverse.addr`. See https://docs.ens.domains/deploying-ens-on-a-private-chain#deploy-the-reverse-registrar