### PR TITLE
Fix name display in watched names

### DIFF
--- a/src/name_bazaar/ui/subs/watched_names_subs.cljs
+++ b/src/name_bazaar/ui/subs/watched_names_subs.cljs
@@ -12,12 +12,15 @@
   :watched-names/watched-items
   :<- [:watched-names]
   :<- [:ens/records]
-  (fn [[watched-names ens-records]]
+  :<- [:offerings]
+  (fn [[watched-names ens-records offerings]]
     (map (fn [node]
            (let [{:keys [:ens.record/name] :as watched-ens-record} (get-in watched-names [:ens/records node])]
              (merge
                watched-ens-record
-               {:ens.record/node node})))
+               {:ens.record/node node}
+               (if-let [offering-address (get-in ens-records [node :ens.record/active-offering])]
+                 (get offerings offering-address)))))
          (:order watched-names))))
 
 (reg-sub


### PR DESCRIPTION
I accidentally deleted display of offering details in Watched names page during #184. After this update they're displayed properly again.