### PR TITLE
One tx offering setup

### DIFF
--- a/resources/public/contracts/src/AuctionOfferingFactory.sol
+++ b/resources/public/contracts/src/AuctionOfferingFactory.sol
@@ -22,14 +22,14 @@ contract AuctionOfferingFactory is OfferingFactory {
     }
 
     /**
-    * @dev Deploys new Auction offering and registers it to OfferingRegistry
+    * @dev Deploys new auction offering and registers it to OfferingRegistry
     * @param name string Plaintext ENS name
     * @param startPrice uint The start price of the auction
     * @param endTime uint The end time of the auction
     * @param extensionDuration uint The extension duration of the auction
     * @param minBidIncrease uint The min bid increase of the auction
     */
-    function createOffering(
+    function createSubnameOffering(
         // WARNING: The contract DOES NOT perform ENS name normalisation, which is up to responsibility of each offchain UI!
         string calldata name,
         uint startPrice,
@@ -57,8 +57,63 @@ contract AuctionOfferingFactory is OfferingFactory {
         registerSubnameOffering(node, labelHash, forwarder, version);
     }
 
-    function onERC721Received(address from, address to, uint256 tokenId, bytes memory data) public returns (bytes4) {
+    /**
+    * @dev Deploys new TLD auction offering and registers it to OfferingRegistry
+    * @param name string Plaintext ENS name
+    * @param startPrice uint The start price of the auction
+    * @param endTime uint The end time of the auction
+    * @param extensionDuration uint The extension duration of the auction
+    * @param minBidIncrease uint The min bid increase of the auction
+    * @param originalOwner address Original owner of the name
+    */
+    function createTLDOffering(
+        // WARNING: The contract DOES NOT perform ENS name normalisation, which is up to responsibility of each offchain UI!
+        string memory name,
+        uint startPrice,
+        uint64 endTime,
+        uint64 extensionDuration,
+        uint minBidIncrease,
+        address payable originalOwner
+    ) internal {
+        address payable forwarder = address(new Forwarder());
+        bytes32 node = namehash(name);
+        bytes32 labelHash = getLabelHash(name);
+        uint128 version = 100001;                   // versioning for Auction offerings starts at number 100000
 
+        AuctionOffering(forwarder).construct(
+            node,
+            name,
+            labelHash,
+            originalOwner,
+            version,
+            startPrice,
+            endTime,
+            extensionDuration,
+            minBidIncrease
+        );
+
+        registerTLDOffering(node, labelHash, forwarder, version, originalOwner);
+    }
+
+    /**
+    * @dev Recognizes being sent .eth subdomain ownership via EthRegistrar and initiates offering creation
+    * @param operator address Who initiated the transfer
+    * @param from address Original owner of the domain
+    * @param tokenId uint256 EthRegistrar identifier of the domain
+    * @param data bytes memory Additional data sent with transfer encoding the desired offering parameters
+    */
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes memory data)
+        public
+        onlyRegistrar
+        returns (bytes4)
+    {
+        (string memory name,
+         uint startPrice,
+         uint64 endTime,
+         uint64 extensionDuration,
+         uint minBidIncrease) = abi.decode(data, (string, uint, uint64, uint64, uint));
+        address payable originalOwner = address(uint160(from));  // address to address payable in Solidity 0.5.x
+        createTLDOffering(name, startPrice, endTime, extensionDuration, minBidIncrease, originalOwner);
         return this.onERC721Received.selector;
     }
 }

--- a/resources/public/contracts/src/AuctionOfferingFactory.sol
+++ b/resources/public/contracts/src/AuctionOfferingFactory.sol
@@ -54,7 +54,12 @@ contract AuctionOfferingFactory is OfferingFactory {
             minBidIncrease
         );
 
-        registerOffering(node, labelHash, forwarder, version);
+        registerSubnameOffering(node, labelHash, forwarder, version);
+    }
+
+    function onERC721Received(address from, address to, uint256 tokenId, bytes memory data) public returns (bytes4) {
+
+        return this.onERC721Received.selector;
     }
 }
 

--- a/resources/public/contracts/src/BuyNowOfferingFactory.sol
+++ b/resources/public/contracts/src/BuyNowOfferingFactory.sol
@@ -26,7 +26,7 @@ contract BuyNowOfferingFactory is OfferingFactory {
     * @param name string Plaintext ENS name
     * @param price uint The price of the offering
     */
-    function createOffering(
+    function createSubnameOffering(
         // WARNING: The contract DOES NOT perform ENS name normalisation, which is up to responsibility of each offchain UI!
         string calldata name,
         uint price
@@ -39,13 +39,60 @@ contract BuyNowOfferingFactory is OfferingFactory {
         BuyNowOffering(forwarder).construct(
             node,
             name,
-            getLabelHash(name),
+            labelHash,
             msg.sender,
             version,
             price
         );
 
-        registerOffering(node, labelHash, forwarder, version);
+        registerSubnameOffering(node, labelHash, forwarder, version);
+    }
+
+    /**
+   * @dev Deploys new BuyNow offering for TLD, registers it and gives it name ownership
+   * @param name string Plaintext ENS name
+   * @param price uint The price of the offering
+   * @param originalOwner address Original owner of the name
+   */
+    function createTLDOffering(
+        // WARNING: The contract DOES NOT perform ENS name normalisation, which is up to responsibility of each offchain UI!
+        string memory name,
+        uint price,
+        address payable originalOwner
+    ) internal {
+        bytes32 node = namehash(name);
+        bytes32 labelHash = getLabelHash(name);
+        address payable forwarder = address(new Forwarder());
+        uint128 version = 2; // versioning for BuyNow offerings starts at number 1
+
+        BuyNowOffering(forwarder).construct(
+            node,
+            name,
+            labelHash,
+            originalOwner,
+            version,
+            price
+        );
+
+        registerTLDOffering(node, labelHash, forwarder, version, originalOwner);
+    }
+
+    /**
+    * @dev Recognizes being sent .eth subdomain ownership via EthRegistrar and initiates offering creation
+    * @param operator address Who initiated the transfer
+    * @param from address Original owner of the domain
+    * @param tokenId uint256 EthRegistrar identifier of the domain
+    * @param data bytes memory Additional data sent with transfer encoding the desired offering parameters
+    */
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes memory data)
+        public
+        onlyRegistrar
+        returns (bytes4)
+    {
+        (string memory name, uint price) = abi.decode(data, (string, uint));
+        address payable originalOwner = address(uint160(from));  // address to address payable in Solidity 0.5.x
+        createTLDOffering(name, price, originalOwner);
+        return this.onERC721Received.selector;
     }
 }
 

--- a/resources/public/contracts/src/OfferingRegistry.sol
+++ b/resources/public/contracts/src/OfferingRegistry.sol
@@ -37,7 +37,7 @@ contract OfferingRegistry is UsedByFactories {
      * Only offering factory can run this function
      * @param offering address Address of newly created offering
      * @param node bytes32 ENS node associated with new offering
-     * @param owner address Owner of the ENS name and creator of the offering
+     * @param owner address Original owner of the ENS name and creator of the offering
      * @param version uint Version of offering contract
      */
     function addOffering(address offering, bytes32 node, address owner, uint version)

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -36,6 +36,8 @@
 <script src="/js/vendor/eth-ens-namehash.js"></script>
 <script src="/js/vendor/sha3.min.js"></script>
 <script src="/js/compiled/app.js?v=28"></script>
+<!-- Ethers is here only for its ABI coder. Remove when updating to a web3 version that exposes its own one. -->
+<script type="text/javascript" src="https://unpkg.com/ethers@5.0.8/dist/ethers-all.umd.min.js"></script>
 <script type="text/javascript" src="https://unpkg.com/web3modal@1.9.0/dist/index.js"></script>
 <script type="text/javascript" src="https://unpkg.com/@walletconnect/web3-provider@1.2.1/dist/umd/index.min.js"></script>
 <script>name_bazaar.ui.core.init();</script>

--- a/src/district0x/shared/utils.cljs
+++ b/src/district0x/shared/utils.cljs
@@ -233,3 +233,7 @@
 
 ;; https://martinklepsch.org/posts/simple-debouncing-in-clojurescript.html
 (def debounce goog-functions/debounce)
+
+;; TODO this should be in cljs-web3-next
+(defn abi-encode-params [provider types params]
+  (js-invoke (aget provider "eth" "abi") "encodeParameters" (clj->js types) (clj->js params)))

--- a/src/name_bazaar/server/contracts_api/auction_offering_factory.cljs
+++ b/src/name_bazaar/server/contracts_api/auction_offering_factory.cljs
@@ -1,18 +1,34 @@
 (ns name-bazaar.server.contracts-api.auction-offering-factory
   (:require
-    [district.server.smart-contracts :refer [contract-call contract-send]]))
+    [district.server.smart-contracts :refer [contract-address contract-call contract-send]]
+    [district.server.web3 :refer [web3]]
+    [district0x.shared.utils :refer [abi-encode-params]]
+    [name-bazaar.shared.utils :refer [name-label top-level-name?]]))
+
+(def sha3 (comp (partial str "0x") (aget (js/require "js-sha3") "keccak_256")))
 
 (defn create-offering! [args opts]
-  (contract-send :auction-offering-factory
-                 :create-offering
-                 ((juxt :offering/name
-                        :offering/price
-                        :auction-offering/end-time
-                        :auction-offering/extension-duration
-                        :auction-offering/min-bid-increase)
-                  args)
-                 (merge {:gas 1000000}
-                        opts)))
+  (let [args-order [:offering/name
+                    :offering/price
+                    :auction-offering/end-time
+                    :auction-offering/extension-duration
+                    :auction-offering/min-bid-increase]]
+    (if (top-level-name? (:offering/name args))
+      (contract-send :eth-registrar
+                     :safe-transfer-from
+                     [(:from opts)
+                      (contract-address :auction-offering-factory)
+                      (sha3 (name-label (:offering/name args)))
+                      (abi-encode-params @web3
+                                         ["string" "uint" "uint64" "uint64" "uint"]
+                                         ((apply juxt args-order) args))]
+                     (merge {:gas 500000}
+                            opts))
+      (contract-send :auction-offering-factory
+                     :create-subname-offering
+                     ((apply juxt args-order) args)
+                     (merge {:gas 500000}
+                            opts)))))
 
 (defn ens []
   (contract-call :auction-offering-factory :ens))

--- a/src/name_bazaar/server/contracts_api/buy_now_offering_factory.cljs
+++ b/src/name_bazaar/server/contracts_api/buy_now_offering_factory.cljs
@@ -1,12 +1,27 @@
 (ns name-bazaar.server.contracts-api.buy-now-offering-factory
   (:require
-    [district.server.smart-contracts :refer [contract-call contract-send]]))
+    [district.server.smart-contracts :refer [contract-address contract-call contract-send]]
+    [district.server.web3 :refer [web3]]
+    [district0x.shared.utils :refer [abi-encode-params]]
+    [name-bazaar.shared.utils :refer [name-label top-level-name?]]))
+
+(def sha3 (comp (partial str "0x") (aget (js/require "js-sha3") "keccak_256")))
 
 (defn create-offering! [{:keys [:offering/name :offering/price]} opts]
-  (contract-send :buy-now-offering-factory
-                 :create-offering
-                 [name price]
-                 (merge {:gas 1000000} opts)))
+  (if (top-level-name? name)
+    (contract-send :eth-registrar
+                   :safe-transfer-from
+                   [(:from opts)
+                    (contract-address :buy-now-offering-factory)
+                    (sha3 (name-label name))
+                    (abi-encode-params @web3
+                                       ["string" "uint"]
+                                       [name price])]
+                   (merge {:gas 450000} opts))
+    (contract-send :buy-now-offering-factory
+                   :create-subname-offering
+                   [name price]
+                   (merge {:gas 450000} opts))))
 
 (defn ens []
   (contract-call :buy-now-offering-factory :ens))

--- a/src/name_bazaar/ui/utils.cljs
+++ b/src/name_bazaar/ui/utils.cljs
@@ -6,6 +6,7 @@
     [district0x.shared.utils :as d0x-shared-utils]
     [district0x.ui.history :as history]
     [district0x.ui.utils :refer [truncate path-with-query solidity-sha3]]
+    [goog.object]
     [goog.string :as gstring]
     [goog.string.format]
     [name-bazaar.shared.utils :refer [name-label valid-ens-name?]]
@@ -25,6 +26,13 @@
 
 (defn sha3 [x]
   (str "0x" (js/keccak_256 x)))
+
+;; TODO after migrating frontend to new web3, remove ethers and use web3.eth.abi
+(defn abi-encode-params [types params]
+  (js-invoke (reduce goog.object/get js/window ["ethers" "utils" "defaultAbiCoder"])
+             "encode"
+             (clj->js types)
+             (clj->js params)))
 
 (defn seal-bid [label-hash bidder-address bid-value-wei bid-hash]
   {:pre [number? bid-value-wei]}

--- a/test/server/name_bazaar/smart_contract_altering_tests.cljs
+++ b/test/server/name_bazaar/smart_contract_altering_tests.cljs
@@ -45,12 +45,6 @@
         (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
-        (testing "Transferring ownership to the offering"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr1}))]
-            (is tx)))
-
         (testing "Ensuring offering gets the registration"
           (is (= offering (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
@@ -138,12 +132,6 @@
           (is (not (nil? offering))))
 
         (when offering
-          (testing "Transferring ownership to the offering"
-            (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                               :ens.record/owner offering}
-                                              {:from addr1}))]
-              (is tx)))
-
           (testing "Ensuring offering gets the registration"
             (is (= offering (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
@@ -235,12 +223,6 @@
         (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
-        (testing "Transferring ownership to the offering"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr1}))]
-            (is tx)))
-
         (testing "Ensuring offering gets the registration"
           (is (= offering (<! (registrar/registration-owner {:ens.record/label "abc"})))))
 
@@ -293,12 +275,6 @@
         (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
-        (testing "Transferring ownership to the offering"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr1}))]
-            (is tx)))
-
         (testing "Offering can be successfully edited by original owner, throws error if different address tries to edit"
           (let [tx (<! (buy-now-offering/set-settings! {:offering/address offering
                                                         :offering/price (to-wei @web3 0.2 :ether)}
@@ -339,12 +315,6 @@
 
         (testing "On-offering event should fire"
           (is (not (nil? offering))))
-
-        (testing "Transferring ownership to the offering"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr1}))]
-            (is tx)))
 
         (let [t0 (to-epoch (t/plus (<! (now)) (t/weeks 4)))]
           (testing "Auction offering can be edited"

--- a/test/server/name_bazaar/smart_contract_ext_tests.cljs
+++ b/test/server/name_bazaar/smart_contract_ext_tests.cljs
@@ -52,18 +52,6 @@
         (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
-        (testing "Can't place a bid before ownership transfer"
-          (let [tx (<! (auction-offering/bid! {:offering/address offering}
-                                              {:value (to-wei @web3 0.1 :ether)
-                                               :from addr1}))]
-            (is (nil? tx))))
-
-        (testing "Transferring ownership to the offer"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr0}))]
-            (is tx)))
-
         (testing "Can place a proper bid"
           (let [tx (<! (auction-offering/bid! {:offering/address offering}
                                               {:value (to-wei @web3 0.1 :ether)
@@ -275,12 +263,6 @@
         (testing "On-offering event should fire"
           (is (not (nil? offering))))
 
-        (testing "Transferring ownership to the offer"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr1}))]
-            (is tx)))
-
         (testing "Emergency multisig can pause the registry"
           (let [tx (<! (offering-registry/emergency-pause! {:from addr0}))]
             (is tx)))
@@ -335,12 +317,6 @@
 
         (testing "Making an instant offer"
           (is create-offering-tx)
-
-        (testing "Transferring ownership to the offering"
-          (let [tx (<! (registrar/transfer! {:ens.record/label "abc"
-                                             :ens.record/owner offering}
-                                            {:from addr1}))]
-            (is tx)))
 
         (testing "Emergency multisig can pause the registry"
           (let [tx (<! (offering-registry/emergency-pause! {:from addr0}))]


### PR DESCRIPTION
resolves #177 

For .eth subdomains (i.e. top level domains) it's possible to create offering and transfer ownership into it in one transaction.

We must start with ownership transfer, as that needs the original owner's authority. We transfer onto OfferingFactory, as no offering exists yet. EthRegistrar then notifies OfferingFactory that it's receiving a token, also passing to it encoded offering parameters. With this information the OfferingFactory is able to create the offering and give it the name ownership.

We use two workarounds of web3 0.19.0 issues: it's not exposing an abi coder and has an issue with overloaded s.c. functions. The workarounds can be removed after frontend web3 upgrade.

User can still reclaim a top level name from offering and then transfer it back manually.