### PR TITLE
Make OfferingRegistry a proxy contract

### DIFF
--- a/resources/public/contracts/src/AuctionOfferingFactory.sol
+++ b/resources/public/contracts/src/AuctionOfferingFactory.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.4;
 import "./OfferingRegistry.sol";
 import "./OfferingFactory.sol";
 import "./AuctionOffering.sol";
-import "./Forwarder.sol";
+import "./proxy/Forwarder.sol";
 
 contract AuctionOfferingFactory is OfferingFactory {
 

--- a/resources/public/contracts/src/BuyNowOfferingFactory.sol
+++ b/resources/public/contracts/src/BuyNowOfferingFactory.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.4;
 import "./OfferingRegistry.sol";
 import "./OfferingFactory.sol";
 import "./BuyNowOffering.sol";
-import "./Forwarder.sol";
+import "./proxy/Forwarder.sol";
 
 contract BuyNowOfferingFactory is OfferingFactory {
 

--- a/resources/public/contracts/src/proxy/DelegateProxy.sol
+++ b/resources/public/contracts/src/proxy/DelegateProxy.sol
@@ -1,8 +1,5 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
-
-/**
- * @dev This file is stripped version of Aragon's ForwarderFactory.sol (https://github.com/aragon/apm-contracts/blob/master/contracts/ForwarderFactory.sol)
- */
 
 contract DelegateProxy {
     /**
@@ -18,17 +15,5 @@ contract DelegateProxy {
         switch result case 0 { invalid() }
         return (0, len)
         }
-    }
-}
-
-contract Forwarder is DelegateProxy {
-    // After compiling contract, `beefbeef...` is replaced in the bytecode by the real target address
-    address constant target = 0xBEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef; // checksumed to silence warning
-
-    /*
-    * @dev Forwards all calls to target
-    */
-    fallback() external payable {
-        delegatedFwd(target, msg.data);
     }
 }

--- a/resources/public/contracts/src/proxy/Forwarder.sol
+++ b/resources/public/contracts/src/proxy/Forwarder.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./DelegateProxy.sol";
+
+contract Forwarder is DelegateProxy {
+    // After compiling contract, `beefbeef...` is replaced in the bytecode by the real target address
+    address constant target = 0xBEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef; // checksummed to silence warning
+
+    /*
+    * @dev Forwards all calls to target
+    */
+    fallback() external payable {
+        delegatedFwd(target, msg.data);
+    }
+}

--- a/resources/public/contracts/src/proxy/MutableForwarder.sol
+++ b/resources/public/contracts/src/proxy/MutableForwarder.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./DelegateProxy.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title Forwarder proxy contract with editable target
+ *
+ * @dev For OfferingRegistry contract we use mutable forwarder instead of using the contract directly.
+ * This is for better upgradeability. Since OfferingRegistry fires all events related to offerings,
+ * we want to be able to access whole history of events always on the same address. Which would be the
+ * address of a MutableForwarder. When OfferingRegistry contract is replaced with an updated one,
+ * mutable forwarder just replaces target and all events stay still accessible on the same address.
+ */
+contract MutableForwarder is DelegateProxy, Ownable {
+    address public target = 0xBEeFbeefbEefbeEFbeEfbEEfBEeFbeEfBeEfBeef; // checksummed to silence warning
+
+    /**
+     * @dev Replaces target forwarder contract is pointing to
+     * Only owner can replace target
+
+     * @param _target New target to proxy into
+    */
+    function setTarget(address _target) public onlyOwner {
+        target = _target;
+    }
+
+    fallback() external payable {
+        delegatedFwd(target, msg.data);
+    }
+}


### PR DESCRIPTION
### Summary

resolves #188

### Review notes
Storage layout conflicts are a concern when using patterns with delegatecalls (https://mixbytes.io/blog/collisions-solidity-storage-layouts). Our MutableForwarder is simple enough to keep track of this and its simplicity is an advantage, but it could also be considered to use some well established Proxy implementation that would hide the storage concerns from our code.
