### PR TITLE
Quick fix to work with Metamask 9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -198,8 +198,10 @@
                         :source-paths ["src"]
                         :compiler {:main "name-bazaar.ui.core"
                                    :output-to "resources/public/js/compiled/app.js"
+                                   :output-dir "resources/public/js/compiled"
                                    :optimizations :advanced
                                    :closure-defines {name-bazaar.ui.config.environment "qa"}
+                                   :source-map "resources/public/js/compiled/app.js.map"
                                    :pretty-print false
                                    :pseudo-names false}}
 

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -24,6 +24,8 @@
         <img style="width: 100%; max-width: 321px;" src="/images/bicycle.svg">
     </div>
 </div>
+<!-- The legacy-web3 script must run BEFORE your other scripts. -->
+<script src="https://unpkg.com/@metamask/legacy-web3@latest/dist/metamask.web3.min.js"></script>
 <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
### Summary

Temporary fix to work with Metamask 9+. Proper fix will require changes in district0x dependencies. See https://docs.metamask.io/guide/provider-migration.html#migrating-to-the-new-provider-api
